### PR TITLE
Update RegisterHTTPFunction signature

### DIFF
--- a/framework/framework.go
+++ b/framework/framework.go
@@ -36,8 +36,12 @@ const (
 )
 
 // RegisterHTTPFunction registers fn as an HTTP function.
-func RegisterHTTPFunction(path string, fn func(http.ResponseWriter, *http.Request)) {
-	registerHTTPFunction(path, fn, http.DefaultServeMux)
+func RegisterHTTPFunction(path string, fn interface{}) {
+	fnHTTP, ok := fn.(func(http.ResponseWriter, *http.Request))
+	if !ok {
+		panic("expected function to have signature func(http.ResponseWriter, *http.Request)")
+	}
+	registerHTTPFunction(path, fnHTTP, http.DefaultServeMux)
 }
 
 // RegisterEventFunction registers fn as an event function. The function must have two arguments, a


### PR DESCRIPTION
It should expose an interface and validate at runtime, so that if
statements can be used in the invoking main function. For example:

if isHTTP() {
	framework.RegisterHTTPFunction("/", fn.HelloWorld)
} else {
	framework.RegisterEventFunction("/", fn.HelloWorld)
}

won't compile for all possible inputs unless both Register*Function
types expose and interface{} and validate later.