### PR TITLE
Improve error message reporting for event functions

### DIFF
--- a/framework/framework.go
+++ b/framework/framework.go
@@ -184,7 +184,7 @@ func readHTTPRequestBody(w http.ResponseWriter, r *http.Request) []byte {
 func runUserFunction(w http.ResponseWriter, r *http.Request, data []byte, fn interface{}) {
 	argVal := reflect.New(reflect.TypeOf(fn).In(1))
 	if err := json.Unmarshal(data, argVal.Interface()); err != nil {
-		writeHTTPErrorResponse(w, http.StatusUnsupportedMediaType, crashStatus, fmt.Sprintf("Error while converting event data: %s", err.Error()))
+		writeHTTPErrorResponse(w, http.StatusUnsupportedMediaType, crashStatus, fmt.Sprintf("Error: %s while converting event data: %s", err.Error(), string(data)))
 		return
 	}
 

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -184,7 +184,7 @@ func readHTTPRequestBody(w http.ResponseWriter, r *http.Request) []byte {
 func runUserFunction(w http.ResponseWriter, r *http.Request, data []byte, fn interface{}) {
 	argVal := reflect.New(reflect.TypeOf(fn).In(1))
 	if err := json.Unmarshal(data, argVal.Interface()); err != nil {
-		writeHTTPErrorResponse(w, http.StatusUnsupportedMediaType, crashStatus, fmt.Sprintf("Error: %s while converting event data: %s", err.Error(), string(data)))
+		writeHTTPErrorResponse(w, http.StatusUnsupportedMediaType, crashStatus, fmt.Sprintf("Error: %s, while converting event data: %s", err.Error(), string(data)))
 		return
 	}
 


### PR DESCRIPTION
BEFORE:
Error while converting event data: json: cannot unmarshal object into Go struct field test.data of type string

AFTER:
Error: json: cannot unmarshal object into Go struct field test.data of type string, while converting event data: {"data": test"} 