### PR TITLE
Update package name to funcframework

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,20 +90,20 @@ handling logic.
 		"log"
 		"os"
 
-		"github.com/GoogleCloudPlatform/functions-framework-go/framework"
+		"github.com/GoogleCloudPlatform/functions-framework-go/funcframework"
 		"example.com/hello"
 	)
 
 	func main() {
-		framework.RegisterHTTPFunction("/", hello.HelloWorld)
+		funcframework.RegisterHTTPFunction("/", hello.HelloWorld)
 		// Use PORT environment variable, or default to 8080.
 		port := "8080"
 		if envPort := os.Getenv("PORT"); envPort != "" {
 			port = envPort
 		}
 
-		if err := framework.Start(port); err != nil {
-			log.Fatalf("framework.Start: %v\n", err)
+		if err := funcframework.Start(port); err != nil {
+			log.Fatalf("funcframework.Start: %v\n", err)
 		}
 	}
 	```
@@ -155,16 +155,16 @@ To select a port, set the `$PORT` environment variable when running.
 PORT=8000 ./cmd
 ```
 
-To select a function, pass your function to `framework.RegisterHTTPFunction` in the second variable.
+To select a function, pass your function to `funcframework.RegisterHTTPFunction` in the second variable.
 
 ```golang
-framework.RegisterHTTPFunction("/", myFunction);
+funcframework.RegisterHTTPFunction("/", myFunction);
 ```
 
-If your function handles events, use `framework.RegisterEventFunction` instead of `framework.RegisterHTTPFunction`.
+If your function handles events, use `funcframework.RegisterEventFunction` instead of `funcframework.RegisterHTTPFunction`.
 
 ```golang
-framework.RegisterEventFunction("/", eventFunction);
+funcframework.RegisterEventFunction("/", eventFunction);
 
 func eventFunction(ctx context.Context, e myEventType){
 	// function logic

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -1,0 +1,274 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package funcframework is a Functions Framework implementation for Go. It allows you to register
+// HTTP and event functions, then start an HTTP server serving those functions.
+package funcframework
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"reflect"
+	"runtime/debug"
+	"strings"
+
+	"cloud.google.com/go/functions/metadata"
+)
+
+const (
+	functionStatusHeader = "X-Google-Status"
+	crashStatus          = "crash"
+	errorStatus          = "error"
+)
+
+// RegisterHTTPFunction registers fn as an HTTP function.
+func RegisterHTTPFunction(path string, fn interface{}) {
+	fnHTTP, ok := fn.(func(http.ResponseWriter, *http.Request))
+	if !ok {
+		panic("expected function to have signature func(http.ResponseWriter, *http.Request)")
+	}
+	registerHTTPFunction(path, fnHTTP, http.DefaultServeMux)
+}
+
+// RegisterEventFunction registers fn as an event function. The function must have two arguments, a
+// context.Context and a struct type depending on the event, and return an error. If fn has the
+// wrong signature, RegisterEventFunction panics.
+func RegisterEventFunction(path string, fn interface{}) {
+	registerEventFunction(path, fn, http.DefaultServeMux)
+}
+
+// Start serves an HTTP server with registered function(s).
+func Start(port string) error {
+	// Check if we have a function resource set, and if so, log progress.
+	if os.Getenv("K_SERVICE") == "" {
+		fmt.Println("Serving function...")
+	}
+	return http.ListenAndServe(":"+port, nil)
+}
+
+func registerHTTPFunction(path string, fn func(http.ResponseWriter, *http.Request), h *http.ServeMux) {
+	h.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		// TODO(b/111823046): Remove following once Cloud Functions does not need flushing the logs anymore.
+		// Force flush of logs after every function trigger.
+		defer fmt.Println()
+		defer fmt.Fprintln(os.Stderr)
+		defer func() {
+			if r := recover(); r != nil {
+				writeHTTPErrorResponse(w, http.StatusInternalServerError, crashStatus, fmt.Sprintf("Function panic: %v\n\n%s", r, debug.Stack()))
+			}
+		}()
+		fn(w, r)
+	})
+}
+
+func registerEventFunction(path string, fn interface{}, h *http.ServeMux) {
+	validateEventFunction(fn)
+	h.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		// TODO(b/111823046): Remove following once Cloud Functions does not need flushing the logs anymore.
+		// Force flush of logs after every function trigger.
+		defer fmt.Println()
+		defer fmt.Fprintln(os.Stderr)
+		defer func() {
+			if r := recover(); r != nil {
+				writeHTTPErrorResponse(w, http.StatusInternalServerError, crashStatus, fmt.Sprintf("Function panic: %v\n\n%s", r, debug.Stack()))
+			}
+		}()
+		handleEventFunction(w, r, fn)
+	})
+}
+
+func validateEventFunction(fn interface{}) {
+	ft := reflect.TypeOf(fn)
+	if ft.NumIn() != 2 {
+		panic(fmt.Sprintf("expected function to have two parameters, found %d", ft.NumIn()))
+	}
+	var err error
+	errorType := reflect.TypeOf(&err).Elem()
+	if ft.NumOut() != 1 || !ft.Out(0).AssignableTo(errorType) {
+		panic("expected function to return only an error")
+	}
+	var ctx context.Context
+	ctxType := reflect.TypeOf(&ctx).Elem()
+	if !ctxType.AssignableTo(ft.In(0)) {
+		panic("expected first parameter to be context.Context")
+	}
+}
+
+func isStructuredCloudEvent(r *http.Request) bool {
+	ceReqHeaders := []string{"Ce-Type", "Ce-Specversion", "Ce-Source", "Ce-Id"}
+	for _, h := range ceReqHeaders {
+		if _, ok := r.Header[http.CanonicalHeaderKey(h)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func getLegacyCloudEvent(r *http.Request, body []byte) (*metadata.Metadata, interface{}, error) {
+	// Handle legacy events' "data" and "context" fields.
+	event := struct {
+		Data     interface{}        `json:"data"`
+		Metadata *metadata.Metadata `json:"context"`
+	}{}
+	if err := json.Unmarshal(body, &event); err != nil {
+		return nil, nil, err
+	}
+
+	// If there is no "data" payload, this isn't a legacy cloud event, but that's okay.
+	if event.Data == nil {
+		return nil, nil, nil
+	}
+
+	// If the "context" field was present, we have a complete event and so return.
+	if event.Metadata != nil {
+		return event.Metadata, event.Data, nil
+	}
+
+	// Otherwise, try to directly populate a metadata object.
+	m := &metadata.Metadata{}
+	if err := json.Unmarshal(body, m); err != nil {
+		return nil, nil, err
+	}
+
+	// Check for event ID to see if this is a legacy event, but if not that's okay.
+	if m.EventID == "" {
+		return nil, nil, nil
+	}
+
+	return m, event.Data, nil
+}
+
+func handleEventFunction(w http.ResponseWriter, r *http.Request, fn interface{}) {
+	body := readHTTPRequestBody(w, r)
+	if body == nil {
+		// No body, error has already been written.
+		return
+	}
+
+	// Structured cloud events contain the context in the header, so we need to parse that out.
+	if isStructuredCloudEvent(r) {
+		runStructuredCloudEvent(w, r, body, fn)
+		return
+	}
+
+	// Legacy cloud events (e.g. pubsub) have data and an associated metdata, so parse those and run if present.
+	if metadata, data, err := getLegacyCloudEvent(r, body); err != nil {
+		writeHTTPErrorResponse(w, http.StatusBadRequest, crashStatus, fmt.Sprintf("Error: %s, parsing legacy cloud event: %s", err.Error(), string(body)))
+		return
+	} else if data != nil && metadata != nil {
+		runLegacyCloudEvent(w, r, metadata, data, fn)
+		return
+	}
+
+	// Otherwise, we assume the body is a JSON blob containing the user-specified data structure.
+	runUserFunction(w, r, body, fn)
+	return
+}
+
+func runStructuredCloudEvent(w http.ResponseWriter, r *http.Request, body []byte, fn interface{}) {
+	// Parse the request to extract the context and the body for the data.
+	event := make(map[string]interface{})
+	event["data"] = string(body)
+	for k, v := range r.Header {
+		k = strings.ToLower(k)
+		if !strings.HasPrefix(k, "ce-") {
+			continue
+		}
+		k = strings.TrimPrefix(k, "ce-")
+		if len(v) != 1 {
+			writeHTTPErrorResponse(w, http.StatusBadRequest, crashStatus, fmt.Sprintf("Too many header values: %s", k))
+			return
+		}
+		var mapVal map[string]interface{}
+		if err := json.Unmarshal([]byte(v[0]), &mapVal); err != nil {
+			// If there's an error, represent the field as the string from the header. Errors will be caught by the event constructor if present.
+			event[k] = v[0]
+		} else {
+			// Otherwise, represent the unmarshalled map value.
+			event[k] = mapVal
+		}
+	}
+
+	// We don't want any escaping to happen here.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(event)
+	if err != nil {
+		writeHTTPErrorResponse(w, http.StatusBadRequest, crashStatus, fmt.Sprintf("Unable to construct event %v: %s", event, err.Error()))
+		return
+	}
+
+	runUserFunction(w, r, buf.Bytes(), fn)
+}
+
+func runLegacyCloudEvent(w http.ResponseWriter, r *http.Request, m *metadata.Metadata, data, fn interface{}) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(data); err != nil {
+		writeHTTPErrorResponse(w, http.StatusBadRequest, crashStatus, fmt.Sprintf("Unable to encode data %v: %s", data, err.Error()))
+		return
+	}
+	ctx := metadata.NewContext(r.Context(), m)
+	runUserFunctionWithContext(ctx, w, r, buf.Bytes(), fn)
+}
+
+func readHTTPRequestBody(w http.ResponseWriter, r *http.Request) []byte {
+	if r.Body == nil {
+		writeHTTPErrorResponse(w, http.StatusBadRequest, crashStatus, "Request body not found")
+		return nil
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		writeHTTPErrorResponse(w, http.StatusUnsupportedMediaType, crashStatus, fmt.Sprintf("Could not read request body %s: %s", r.Body, err.Error()))
+		return nil
+	}
+
+	return body
+}
+
+func runUserFunction(w http.ResponseWriter, r *http.Request, data []byte, fn interface{}) {
+	runUserFunctionWithContext(r.Context(), w, r, data, fn)
+}
+
+func runUserFunctionWithContext(ctx context.Context, w http.ResponseWriter, r *http.Request, data []byte, fn interface{}) {
+	argVal := reflect.New(reflect.TypeOf(fn).In(1))
+	if err := json.Unmarshal(data, argVal.Interface()); err != nil {
+		writeHTTPErrorResponse(w, http.StatusUnsupportedMediaType, crashStatus, fmt.Sprintf("Error: %s, while converting event data: %s", err.Error(), string(data)))
+		return
+	}
+
+	userFunErr := reflect.ValueOf(fn).Call([]reflect.Value{
+		reflect.ValueOf(ctx),
+		argVal.Elem(),
+	})
+	if userFunErr[0].Interface() != nil {
+		writeHTTPErrorResponse(w, http.StatusInternalServerError, errorStatus, fmt.Sprintf("Function error: %v", userFunErr[0]))
+		return
+	}
+}
+
+func writeHTTPErrorResponse(w http.ResponseWriter, statusCode int, status, msg string) {
+	w.Header().Set(functionStatusHeader, status)
+	w.WriteHeader(statusCode)
+	fmt.Fprintf(os.Stderr, msg)
+	fmt.Fprintf(w, msg)
+}

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -1,0 +1,243 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funcframework
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+)
+
+func TestHTTPFunction(t *testing.T) {
+	h := http.NewServeMux()
+	registerHTTPFunction("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "Hello World!")
+	}, h)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ioutil.ReadAll: %v", err)
+	}
+
+	if got, want := string(body), "Hello World!"; got != want {
+		t.Fatalf("TestHTTPFunction: got %v; want %v", got, want)
+	}
+}
+
+type customStruct struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type eventData struct {
+	Data string `json:"data"`
+}
+
+func TestEventFunction(t *testing.T) {
+	cloudeventsJSON := []byte(`{
+		"specversion" : "0.3",
+		"type" : "com.github.pull.create",
+		"source" : "https://github.com/cloudevents/spec/pull",
+		"subject" : "123",
+		"id" : "A234-1234-1234",
+		"time" : "2018-04-05T17:31:00Z",
+		"comexampleextension1" : "value",
+		"comexampleextension2" : {"othervalue":5},
+		"datacontenttype" : "text/xml",
+		"data" : "<much wow=\"xml\"/>"
+	}`)
+	var testCE cloudevents.Event
+	err := json.Unmarshal(cloudeventsJSON, &testCE)
+	if err != nil {
+		t.Fatalf("TestEventFunction: unable to create Event from JSON: %v", err)
+	}
+
+	var tests = []struct {
+		name      string
+		data      []byte
+		fn        interface{}
+		status    int
+		header    string
+		ceHeaders map[string]string
+	}{
+		{
+			name: "valid function",
+			data: []byte(`{"id": 12345,"name": "custom"}`),
+			fn: func(c context.Context, s customStruct) error {
+				if s.ID != 12345 {
+					return fmt.Errorf("expected id=12345, got %d", s.ID)
+				}
+				if s.Name != "custom" {
+					return fmt.Errorf("TestEventFunction(valid function): got name=%s, want name=\"custom\"", s.Name)
+				}
+				return nil
+			},
+			status: http.StatusOK,
+			header: "",
+		},
+		{
+			name: "incorrect type",
+			data: []byte(`{"id": 12345,"name": 123}`),
+			fn: func(c context.Context, s customStruct) error {
+				return nil
+			},
+			status: http.StatusUnsupportedMediaType,
+			header: "crash",
+		},
+		{
+			name: "erroring function",
+			data: []byte(`{"id": 12345,"name": "custom"}`),
+			fn: func(c context.Context, s customStruct) error {
+				return fmt.Errorf("TestEventFunction(erroring function): this error should fire")
+			},
+			status: http.StatusInternalServerError,
+			header: "error",
+		},
+		{
+			name: "cloudevent with context from headers",
+			data: []byte("<much wow=\"xml\"/>"),
+			fn: func(c context.Context, e cloudevents.Event) error {
+				if e.String() != testCE.String() {
+					return fmt.Errorf("TestEventFunction(cloudevent with context from header): got: %v, want: %v", e, testCE)
+				}
+				return nil
+			},
+			status: http.StatusOK,
+			header: "",
+			ceHeaders: map[string]string{
+				"ce-specversion":          "0.3",
+				"ce-type":                 "com.github.pull.create",
+				"ce-source":               "https://github.com/cloudevents/spec/pull",
+				"ce-subject":              "123",
+				"ce-id":                   "A234-1234-1234",
+				"ce-time":                 "2018-04-05T17:31:00Z",
+				"ce-comexampleextension1": "value",
+				"ce-comexampleextension2": `{"othervalue": 5}`,
+				"ce-datacontenttype":      "text/xml",
+			},
+		},
+		{
+			name: "binary cloudevent request",
+			data: cloudeventsJSON,
+			fn: func(c context.Context, e cloudevents.Event) error {
+				if e.String() != testCE.String() {
+					return fmt.Errorf("TestEventFunction(binary cloudevent request): got: %v, want: %v", e, testCE)
+				}
+				return nil
+			},
+			status: http.StatusOK,
+			header: "",
+		},
+		{
+			name: "pubsub event",
+			data: []byte(`{
+				"context": {
+					"eventId": "1234567",
+					"timestamp": "2019-11-04T23:01:10.112Z",
+					"eventType": "google.pubsub.topic.publish",
+					"resource": {
+						"service": "pubsub.googleapis.com",
+						"name": "mytopic",
+						"type": "type.googleapis.com/google.pubsub.v1.PubsubMessage"
+					}
+				},
+				"data": {
+					"@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+					"attributes": null,
+					"data": "test data"
+					}
+				}`),
+			fn: func(c context.Context, e eventData) error {
+				if e.Data != "test data" {
+					return fmt.Errorf("TestEventFunction(pubsub event): got: %v, want: 'test data'", e.Data)
+				}
+				return nil
+			},
+			status: http.StatusOK,
+			header: "",
+		},
+		{
+			name: "pubsub legacy event",
+			data: []byte(`{
+				"eventId": "1234567",
+				"timestamp": "2019-11-04T23:01:10.112Z",
+				"eventType": "google.pubsub.topic.publish",
+				"resource": {
+					"service": "pubsub.googleapis.com",
+					"name": "mytopic",
+					"type": "type.googleapis.com/google.pubsub.v1.PubsubMessage"
+				},
+				"data": {
+					"@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+					"attributes": null,
+					"data": "test data"
+					}
+				}`),
+			fn: func(c context.Context, e eventData) error {
+				if e.Data != "test data" {
+					return fmt.Errorf("TestEventFunction(pubsub legacy event): got: %v, want: 'test data'", e.Data)
+				}
+				return nil
+			},
+			status: http.StatusOK,
+			header: "",
+		},
+	}
+
+	for _, tc := range tests {
+		h := http.NewServeMux()
+		registerEventFunction("/", tc.fn, h)
+
+		srv := httptest.NewServer(h)
+		defer srv.Close()
+
+		req, err := http.NewRequest("POST", srv.URL, bytes.NewBuffer(tc.data))
+		req.Header.Set("Content-Type", "application/json")
+		for k, v := range tc.ceHeaders {
+			req.Header.Set(k, v)
+		}
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Errorf("client.Do(%s): %v", tc.name, err)
+			continue
+		}
+
+		if resp.StatusCode != tc.status {
+			t.Errorf("TestEventFunction(%s): response status = %v, want %v", tc.name, resp.StatusCode, tc.status)
+			continue
+		}
+		if resp.Header.Get(functionStatusHeader) != tc.header {
+			t.Errorf("TestEventFunction(%s): response header = %s, want %s", tc.name, resp.Header.Get(functionStatusHeader), tc.header)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
The less generic package name is much preferred.

This is done in two parts. This commit adds the new package, and the
next will remove the old. The transition is done this way to faciliate
the migration to the new package name internally.