### PR TITLE
Ensure loglines from HTTP error response end with a newline, otherwis…

### DIFF
--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -274,7 +274,7 @@ func runUserFunctionWithContext(ctx context.Context, w http.ResponseWriter, r *h
 
 func writeHTTPErrorResponse(w http.ResponseWriter, statusCode int, status, msg string) {
 	// Ensure logs end with a newline otherwise they are grouped incorrectly in SD.
-	if msg!=nil && msg != "" && !strings.HasSuffix(msg, "\n") {
+	if msg != "" && !strings.HasSuffix(msg, "\n") {
 		msg += "\n"
 	}
 	w.Header().Set(functionStatusHeader, status)

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -273,6 +273,10 @@ func runUserFunctionWithContext(ctx context.Context, w http.ResponseWriter, r *h
 }
 
 func writeHTTPErrorResponse(w http.ResponseWriter, statusCode int, status, msg string) {
+	// Ensure logs end with a newline otherwise they are grouped incorrectly in SD.
+	if !strings.HasSuffix(msg, "\n") {
+		msg += "\n"
+	}
 	w.Header().Set(functionStatusHeader, status)
 	w.WriteHeader(statusCode)
 	fmt.Fprintf(os.Stderr, msg)

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -274,7 +274,7 @@ func runUserFunctionWithContext(ctx context.Context, w http.ResponseWriter, r *h
 
 func writeHTTPErrorResponse(w http.ResponseWriter, statusCode int, status, msg string) {
 	// Ensure logs end with a newline otherwise they are grouped incorrectly in SD.
-	if !strings.HasSuffix(msg, "\n") {
+	if msg!=nil && msg != "" && !strings.HasSuffix(msg, "\n") {
 		msg += "\n"
 	}
 	w.Header().Set(functionStatusHeader, status)

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -274,7 +274,7 @@ func runUserFunctionWithContext(ctx context.Context, w http.ResponseWriter, r *h
 
 func writeHTTPErrorResponse(w http.ResponseWriter, statusCode int, status, msg string) {
 	// Ensure logs end with a newline otherwise they are grouped incorrectly in SD.
-	if msg != "" && !strings.HasSuffix(msg, "\n") {
+	if !strings.HasSuffix(msg, "\n") {
 		msg += "\n"
 	}
 	w.Header().Set(functionStatusHeader, status)


### PR DESCRIPTION
…e they are not grouped correctly in Stackdriver logging. Ensures consistent behaviour with GO 1.11