### PR TITLE
Support all receiver signatures from the CloudEvents Go SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ func CloudEventFunction(ctx context.Context, e cloudevents.Event) error {
 }
 ```
 
+For the complete set of supported CloudEvent function signatures, consult the CloudEvent SDK
+documentation [here](https://godoc.org/github.com/cloudevents/sdk-go/v2/client#Client).
+
 These functions are registered with the handler via `funcframework.RegisterCloudEventFunctionContext`.
 
 To learn more about CloudEvents, see the [Go SDK for CloudEvents](https://github.com/cloudevents/sdk-go).

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -92,7 +92,9 @@ func RegisterEventFunctionContext(ctx context.Context, path string, fn interface
 }
 
 // RegisterCloudEventFunctionContext registers fn as an cloudevent function.
-func RegisterCloudEventFunctionContext(ctx context.Context, path string, fn func(context.Context, cloudevents.Event) error) error {
+// This accepts any valid CloudEvents received function.  Consult the CloudEvent
+// Go SDK for the complete list.
+func RegisterCloudEventFunctionContext(ctx context.Context, path string, fn interface{}) error {
 	return registerCloudEventFunction(ctx, path, fn, handler)
 }
 
@@ -138,7 +140,7 @@ func registerEventFunction(path string, fn interface{}, h *http.ServeMux) error 
 	return nil
 }
 
-func registerCloudEventFunction(ctx context.Context, path string, fn func(context.Context, cloudevents.Event) error, h *http.ServeMux) error {
+func registerCloudEventFunction(ctx context.Context, path string, fn interface{}, h *http.ServeMux) error {
 	p, err := cloudevents.NewHTTP()
 	if err != nil {
 		return fmt.Errorf("failed to create protocol: %v", err)


### PR DESCRIPTION
The HTTP and Event callback registration functions already take `interface{}`,
and the CloudEvents SDK already supports a much wider collection of signatures
(if this just let them through!).

With this change CloudEvent functions can reply, which enables invocations from
a Knative Broker to create new events.

This adds a new test for replies.

Fixes: https://github.com/GoogleCloudPlatform/functions-framework-go/issues/58

cc @squee1945