### PR TITLE
fix: Explicitly use localhost as host when starting server to stop warning

### DIFF
--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -103,7 +103,7 @@ func Start(port string) error {
 		fmt.Println("Serving function...")
 	}
 
-	return http.ListenAndServe(":"+port, handler)
+	return http.ListenAndServe("localhost:"+port, handler)
 }
 
 func registerHTTPFunction(path string, fn func(http.ResponseWriter, *http.Request), h *http.ServeMux) error {


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/functions-framework-go/issues/62, an OSX warning starting a server.

Would like a review from someone more knowledgeable in Go.

Tested locally (works, suppresses OSX error)

---

See related articles like:

https://medium.com/@leeprovoost/suppressing-accept-incoming-network-connections-warnings-on-osx-7665b33927ca