### PR TITLE
Run conformance tests without buildpacks

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -6,38 +6,34 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.13'
-    - name: Setup test data
-      run: "./set_up_conformance_tests.sh"
+        go-version: '1.15'
+
     - name: Run HTTP conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
       with:
         functionType: 'http'
-        source: 'testdata'
-        target: 'HTTP'
-        runtime: 'go113'
-        tag: 'go113_20200924_20_RC00'
+        useBuildpacks: false
+        cmd: "'go run testdata/conformance/cmd/http/main.go'"
         startDelay: 10
+
     - name: Run event conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
       with:
         functionType: 'legacyevent'
         validateMapping: false
-        source: 'testdata'
-        target: 'Event'
-        runtime: 'go113'
-        tag: 'go113_20200924_20_RC00'
+        useBuildpacks: false
+        cmd: "'go run testdata/conformance/cmd/legacyevent/main.go'"
         startDelay: 10
+
     - name: Run cloudevent conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
       with:
         functionType: 'cloudevent'
         validateMapping: true
-        source: 'testdata'
-        target: 'CloudEvent'
-        runtime: 'go113'
-        tag: 'go113_20200924_20_RC00'
+        useBuildpacks: false
+        cmd: "'go run testdata/conformance/cmd/cloudevent/main.go'"
         startDelay: 10

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -25,7 +25,7 @@ jobs:
         functionType: 'http'
         useBuildpacks: false
         cmd: "'go run testdata/conformance/cmd/http/main.go'"
-        startDelay: 10
+        startDelay: 5
 
     - name: Run event conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
@@ -34,7 +34,7 @@ jobs:
         validateMapping: false
         useBuildpacks: false
         cmd: "'go run testdata/conformance/cmd/legacyevent/main.go'"
-        startDelay: 10
+        startDelay: 5
 
     - name: Run CloudEvent conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
@@ -43,4 +43,4 @@ jobs:
         validateMapping: true
         useBuildpacks: false
         cmd: "'go run testdata/conformance/cmd/cloudevent/main.go'"
-        startDelay: 10
+        startDelay: 5

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,5 +1,12 @@
 name: Go Conformance CI
-on: push
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-18.04
@@ -13,7 +20,7 @@ jobs:
         go-version: '1.15'
 
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
       with:
         functionType: 'http'
         useBuildpacks: false
@@ -21,7 +28,7 @@ jobs:
         startDelay: 10
 
     - name: Run event conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
       with:
         functionType: 'legacyevent'
         validateMapping: false
@@ -29,8 +36,8 @@ jobs:
         cmd: "'go run testdata/conformance/cmd/legacyevent/main.go'"
         startDelay: 10
 
-    - name: Run cloudevent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
+    - name: Run CloudEvent conformance tests
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
       with:
         functionType: 'cloudevent'
         validateMapping: true

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -9,15 +9,18 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.13, 1.14, 1.15, 1.16]
     steps:
-    - name: Checkout code
+    - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Setup Go
+    - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '${{ matrix.go-version }}'
 
     - name: Run HTTP conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9

--- a/set_up_conformance_tests.sh
+++ b/set_up_conformance_tests.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-pushd testdata
-go get github.com/GoogleCloudPlatform/functions-framework-go@${GITHUB_SHA?}
-popd

--- a/testdata/conformance/cmd/cloudevent/main.go
+++ b/testdata/conformance/cmd/cloudevent/main.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Binary that serves the CloudEvent conformance test function.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/GoogleCloudPlatform/functions-framework-go/funcframework"
+	"github.com/GoogleCloudPlatform/functions-framework-go/testdata/conformance/function"
+)
+
+func main() {
+	ctx := context.Background()
+	if err := funcframework.RegisterCloudEventFunctionContext(ctx, "/", function.CloudEvent); err != nil {
+		log.Fatalf("Failed to register function:: %v", err)
+	}
+
+	port := "8080"
+	if envPort := os.Getenv("PORT"); envPort != "" {
+		port = envPort
+	}
+	if err := funcframework.Start(port); err != nil {
+		log.Fatalf("Failed to start functions framework: %v", err)
+	}
+}

--- a/testdata/conformance/cmd/http/main.go
+++ b/testdata/conformance/cmd/http/main.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Binary that serves the HTTP conformance test function.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/GoogleCloudPlatform/functions-framework-go/funcframework"
+	"github.com/GoogleCloudPlatform/functions-framework-go/testdata/conformance/function"
+)
+
+func main() {
+	ctx := context.Background()
+	if err := funcframework.RegisterHTTPFunctionContext(ctx, "/", function.HTTP); err != nil {
+		log.Fatalf("Failed to register function:: %v", err)
+	}
+
+	port := "8080"
+	if envPort := os.Getenv("PORT"); envPort != "" {
+		port = envPort
+	}
+	if err := funcframework.Start(port); err != nil {
+		log.Fatalf("Failed to start functions framework: %v", err)
+	}
+}

--- a/testdata/conformance/cmd/legacyevent/main.go
+++ b/testdata/conformance/cmd/legacyevent/main.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Binary that serves the legacy/background event conformance test function.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/GoogleCloudPlatform/functions-framework-go/funcframework"
+	"github.com/GoogleCloudPlatform/functions-framework-go/testdata/conformance/function"
+)
+
+func main() {
+	ctx := context.Background()
+	if err := funcframework.RegisterEventFunctionContext(ctx, "/", function.Event); err != nil {
+		log.Fatalf("Failed to register function:: %v", err)
+	}
+
+	port := "8080"
+	if envPort := os.Getenv("PORT"); envPort != "" {
+		port = envPort
+	}
+	if err := funcframework.Start(port); err != nil {
+		log.Fatalf("Failed to start functions framework: %v", err)
+	}
+}

--- a/testdata/conformance/function/function.go
+++ b/testdata/conformance/function/function.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package function contains test functions to validate the framework.
 package function
 

--- a/testdata/go.mod
+++ b/testdata/go.mod
@@ -1,8 +1,0 @@
-module example.com/framework-test
-
-go 1.13
-
-require (
-	cloud.google.com/go v0.67.0
-	github.com/cloudevents/sdk-go/v2 v2.3.1
-)


### PR DESCRIPTION
Running them without buildpacks is more hermetic, faster, and easier
to emulate locally.