### PR TITLE
Fetch go dependencies before running conformance tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,6 +22,10 @@ jobs:
       with:
         go-version: '${{ matrix.go-version }}'
 
+    - run:
+        name: Fetch go dependencies
+        command: 'go get ./...'
+
     - name: Run HTTP conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
       with:


### PR DESCRIPTION
Currently, the first run of "go run ..." has the burden of downloading
and installing all the go depencies, which makes the first test require
a longer startDelay than the other tests.

Adding an independent step before the conformance tests will keep
different conformance tests startup time more consistent.