### PR TITLE
Fix conformance tests configuration

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,8 +22,11 @@ jobs:
       with:
         go-version: '${{ matrix.go-version }}'
 
-    - name: Fetch go dependencies and build
+    - name: Pre-fetch go dependencies and build
       run: 'go build ./...'
+
+    - name: Pre-install conformance test client
+      run: 'go get github.com/GoogleCloudPlatform/functions-framework-conformance/client && go install github.com/GoogleCloudPlatform/functions-framework-conformance/client'
 
     - name: Run HTTP conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,8 +22,8 @@ jobs:
       with:
         go-version: '${{ matrix.go-version }}'
 
-    - name: Fetch go dependencies
-      run: 'go get ./...'
+    - name: Fetch go dependencies and build
+      run: 'go build ./...'
 
     - name: Run HTTP conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,9 +22,8 @@ jobs:
       with:
         go-version: '${{ matrix.go-version }}'
 
-    - run:
-        name: Fetch go dependencies
-        command: 'go get ./...'
+    - name: Fetch go dependencies
+      run: 'go get ./...'
 
     - name: Run HTTP conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9


### PR DESCRIPTION
Need to use GitHub Actions syntax instead of Circle CI syntax.

If there's an error in the GitHub Actions config file, GitHub just skips the Action...

Also, pre-install the conformance test client so that it doesn't count against the first conformance test's `startDelay` during `go run`.

Before:
![image](https://user-images.githubusercontent.com/16651409/117894402-1b0fc900-b271-11eb-8845-8fd36f07af4e.png)

After:
![image](https://user-images.githubusercontent.com/16651409/117894280-de43d200-b270-11eb-977b-7eb105f2cee0.png)


You can see the conformance client is immediately "found" at the start of the HTTP test and no extra go modules have to be downloaded.
