### PR TITLE
chore: add simple release setup for golang functions framework

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,3 @@
+handleGHRelease: true
+releaseType: go
+releaseLabel: "autorelease: published"


### PR DESCRIPTION
Sets up simple release please for simple release notes. (To be generated)

Fixes: https://github.com/GoogleCloudPlatform/functions-framework-go/issues/76

CI failure is unrelated.

---

Simple:
- https://github.com/googleapis/google-api-go-client/blob/master/.github/release-please.yml

Not sure if we should have a more complicated release like:
- https://github.com/googleapis/google-cloud-go/blob/master/.github/workflows/release.yaml

CC: @codyoss