### PR TITLE
feat: enable traceparent header for cloudevents

### DIFF
--- a/funcframework/events.go
+++ b/funcframework/events.go
@@ -341,11 +341,6 @@ func createCloudEventRequest(r *http.Request) (int, error) {
 		ce["subject"] = subject
 	}
 
-	// Set traceparent header.
-	if r.Header.Get("traceparent") != "" {
-		ce["traceparent"] = r.Header.Get("traceparent")
-	}
-
 	encoded, err := json.Marshal(ce)
 	if err != nil {
 		return http.StatusBadRequest, fmt.Errorf("Unable to marshal CloudEvent %v: %v", ce, err)

--- a/funcframework/events.go
+++ b/funcframework/events.go
@@ -341,6 +341,11 @@ func createCloudEventRequest(r *http.Request) (int, error) {
 		ce["subject"] = subject
 	}
 
+	// Set traceparent header.
+	if r.Header.Get("traceparent") != "" {
+		ce["traceparent"] = r.Header.Get("traceparent")
+	}
+
 	encoded, err := json.Marshal(ce)
 	if err != nil {
 		return http.StatusBadRequest, fmt.Errorf("Unable to marshal CloudEvent %v: %v", ce, err)

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -172,7 +172,7 @@ func TestEventFunction(t *testing.T) {
 
 		req, err := http.NewRequest("POST", srv.URL, bytes.NewBuffer(tc.data))
 		if err != nil {
-			t.Fatalf("http.NewRequest: %v", err)
+			t.Fatalf("http.NewRequest err: %v", err)
 		}
 		req.Header.Set("Content-Type", "application/json")
 		for k, v := range tc.ceHeaders {

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -171,6 +171,9 @@ func TestEventFunction(t *testing.T) {
 		defer srv.Close()
 
 		req, err := http.NewRequest("POST", srv.URL, bytes.NewBuffer(tc.data))
+		if err != nil {
+			t.Fatalf("http.NewRequest: %v", err)
+		}
 		req.Header.Set("Content-Type", "application/json")
 		for k, v := range tc.ceHeaders {
 			req.Header.Set(k, v)
@@ -271,6 +274,9 @@ func TestCloudEventFunction(t *testing.T) {
 		defer srv.Close()
 
 		req, err := http.NewRequest("POST", srv.URL, bytes.NewBuffer(tc.data))
+		if err != nil {
+			t.Fatalf("http.NewRequest: %v", err)
+		}
 		for k, v := range tc.ceHeaders {
 			req.Header.Add(k, v)
 		}

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -203,7 +203,8 @@ func TestCloudEventFunction(t *testing.T) {
 		"time" : "2018-04-05T17:31:00Z",
 		"comexampleextension1" : "value",
 		"datacontenttype" : "application/xml",
-		"data" : "<much wow=\"xml\"/>"
+		"data" : "<much wow=\"xml\"/>",
+		"traceparent" : "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
 	}`)
 	var testCE cloudevents.Event
 	err := json.Unmarshal(cloudeventsJSON, &testCE)
@@ -238,6 +239,7 @@ func TestCloudEventFunction(t *testing.T) {
 				"ce-id":                   "A234-1234-1234",
 				"ce-time":                 "2018-04-05T17:31:00Z",
 				"ce-comexampleextension1": "value",
+				"traceparent":             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
 				"Content-Type":            "application/xml",
 			},
 		},


### PR DESCRIPTION
Add the `traceparent` header to the CloudEvent payload for CloudEvent functions.