### PR TITLE
fix: use standard RFC3339 time formatting

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -26,21 +26,21 @@ jobs:
       run: 'go build ./...'
 
     - name: Pre-install conformance test client
-      run: 'go get github.com/GoogleCloudPlatform/functions-framework-conformance/client@v1.1.1 && go install github.com/GoogleCloudPlatform/functions-framework-conformance/client'
+      run: 'go get github.com/GoogleCloudPlatform/functions-framework-conformance/client@v1.2.1 && go install github.com/GoogleCloudPlatform/functions-framework-conformance/client'
 
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.1.1
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.2.1
       with:
-        version: 'v1.0.0'
+        version: 'v1.2.1'
         functionType: 'http'
         useBuildpacks: false
         cmd: "'go run testdata/conformance/cmd/http/main.go'"
         startDelay: 5
 
     - name: Run event conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.1.1
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.2.1
       with:
-        version: 'v1.0.0'
+        version: 'v1.2.1'
         functionType: 'legacyevent'
         validateMapping: true
         useBuildpacks: false
@@ -48,9 +48,9 @@ jobs:
         startDelay: 5
 
     - name: Run CloudEvent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.1.1
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.2.1
       with:
-        version: 'v1.0.0'
+        version: 'v1.2.1'
         functionType: 'cloudevent'
         validateMapping: true
         useBuildpacks: false

--- a/funcframework/events.go
+++ b/funcframework/events.go
@@ -32,9 +32,6 @@ const (
 	storageCEService      = "storage.googleapis.com"
 
 	pubsubMessageType = "type.googleapis.com/google.pubsub.v1.PubsubMessage"
-
-	// timeFmt is the precision that CloudEvents timestamps require.
-	timeFmt = "2006-01-02T15:04:05.000Z"
 )
 
 var (
@@ -330,10 +327,9 @@ func convertBackgroundToCloudEventRequest(r *http.Request) error {
 		return err
 	}
 
-	time := md.Timestamp.Format(timeFmt)
 	ce := map[string]interface{}{
 		"id":              md.EventID,
-		"time":            time,
+		"time":            md.Timestamp,
 		"specversion":     ceSpecVersion,
 		"datacontenttype": "application/json",
 		"type":            t,
@@ -352,7 +348,7 @@ func convertBackgroundToCloudEventRequest(r *http.Request) error {
 			return fmt.Errorf(`invalid "data" field in event payload, "data": %q`, d)
 		}
 
-		data["publishTime"] = time
+		data["publishTime"] = md.Timestamp
 		data["messageId"] = md.EventID
 
 		// In a Pub/Sub CloudEvent "data" is wrapped by "message".

--- a/funcframework/events_test.go
+++ b/funcframework/events_test.go
@@ -353,7 +353,7 @@ func TestConvertBackgroundToCloudEventRequest(t *testing.T) {
 				"notSupported": {
 				},
 				"resource": "projects/my-project-id",
-				"timestamp": "2020-09-29T11:32:00.000Z"
+				"timestamp": "2020-09-29T11:32:00.123Z"
 			  }`,
 			wantCE: `{
 				"specversion": "1.0",
@@ -361,7 +361,7 @@ func TestConvertBackgroundToCloudEventRequest(t *testing.T) {
 				"source": "//firebaseauth.googleapis.com/projects/my-project-id",
 				"subject": "users/UUpby3s4spZre6kHsgVSPetzQ8l2",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json",
 				"data": {
 				  "email": "test@nowhere.com",
@@ -398,7 +398,7 @@ func TestConvertBackgroundToCloudEventRequest(t *testing.T) {
 				  }
 				},
 				"resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-				"timestamp": "2020-09-29T11:32:00.000Z",
+				"timestamp": "2020-09-29T11:32:00.123Z",
 				"eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 			  }`,
 			wantCE: `{
@@ -407,7 +407,7 @@ func TestConvertBackgroundToCloudEventRequest(t *testing.T) {
 				"source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
 				"subject": "refs/gcf-test/xyz",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json",
 				"data": {
 				  "data": null,
@@ -437,7 +437,7 @@ func TestConvertBackgroundToCloudEventRequest(t *testing.T) {
 				  }
 				},
 				"resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-				"timestamp": "2020-09-29T11:32:00.000Z",
+				"timestamp": "2020-09-29T11:32:00.123Z",
 				"eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 			  }`,
 			wantCE: `{
@@ -446,7 +446,7 @@ func TestConvertBackgroundToCloudEventRequest(t *testing.T) {
 				"source": "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id",
 				"subject": "refs/gcf-test/xyz",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json",
 				"data": {
 				  "data": {
@@ -515,14 +515,14 @@ func TestConvertCloudEventToBackgroundRequest(t *testing.T) {
 				"type": "google.cloud.pubsub.topic.v1.messagePublished",
 				"source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json",
 				"data": {
 				  "subscription": "projects/sample-project/subscriptions/sample-subscription",
 				  "message": {
 					"@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
 					"messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-					"publishTime": "2020-09-29T11:32:00.000Z",
+					"publishTime": "2020-09-29T11:32:00.123Z",
 					"attributes": {
 					   "attr1":"attr1-value"
 					},
@@ -533,7 +533,7 @@ func TestConvertCloudEventToBackgroundRequest(t *testing.T) {
 			wantBE: `{
 				"context": {
 				   "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
-				   "timestamp":"2020-09-29T11:32:00.000Z",
+				   "timestamp":"2020-09-29T11:32:00.123Z",
 				   "eventType":"google.pubsub.topic.publish",
 				   "resource":{
 					 "service":"pubsub.googleapis.com",
@@ -558,7 +558,7 @@ func TestConvertCloudEventToBackgroundRequest(t *testing.T) {
 				"source": "//firebaseauth.googleapis.com/projects/my-project-id",
 				"subject": "users/UUpby3s4spZre6kHsgVSPetzQ8l2",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json",
 				"data": {
 				  "email": "test@nowhere.com",
@@ -596,7 +596,7 @@ func TestConvertCloudEventToBackgroundRequest(t *testing.T) {
 				  "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
 				  "eventType": "providers/firebase.auth/eventTypes/user.create",
 				  "resource": "projects/my-project-id",
-				  "timestamp": "2020-09-29T11:32:00.000Z"
+				  "timestamp": "2020-09-29T11:32:00.123Z"
 				}
 			  }`,
 		},
@@ -608,7 +608,7 @@ func TestConvertCloudEventToBackgroundRequest(t *testing.T) {
 				"source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
 				"subject": "refs/gcf-test/xyz",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json",
 				"data": {
 				  "data": null,
@@ -627,7 +627,7 @@ func TestConvertCloudEventToBackgroundRequest(t *testing.T) {
 				},
 				"context": {
 				  "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-				  "timestamp": "2020-09-29T11:32:00.000Z",
+				  "timestamp": "2020-09-29T11:32:00.123Z",
 				  "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
 				  "eventType": "providers/google.firebase.database/eventTypes/ref.write" 
 				}
@@ -641,7 +641,7 @@ func TestConvertCloudEventToBackgroundRequest(t *testing.T) {
 				"source": "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id",
 				"subject": "refs/gcf-test/xyz",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json",
 				"data": {
 				  "data": {
@@ -663,7 +663,7 @@ func TestConvertCloudEventToBackgroundRequest(t *testing.T) {
 				},
 				"context": {
 				  "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
-				  "timestamp": "2020-09-29T11:32:00.000Z",
+				  "timestamp": "2020-09-29T11:32:00.123Z",
 				  "eventType": "providers/google.firebase.database/eventTypes/ref.write",
 				  "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
 				}
@@ -677,7 +677,7 @@ func TestConvertCloudEventToBackgroundRequest(t *testing.T) {
 				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
 				"subject": "objects/folder/Test.cs",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json",
 				"data": {
 				  "bucket": "some-bucket",
@@ -702,7 +702,7 @@ func TestConvertCloudEventToBackgroundRequest(t *testing.T) {
 			wantBE: `{
 				"context": {
 				   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				   "timestamp": "2020-09-29T11:32:00.000Z",
+				   "timestamp": "2020-09-29T11:32:00.123Z",
 				   "eventType": "google.storage.object.finalize",
 				   "resource": {
 					  "service": "storage.googleapis.com",
@@ -749,7 +749,7 @@ func TestConvertCloudEventToBackgroundRequest(t *testing.T) {
 			req.Header.Set("ce-source", ce.Source())
 			req.Header.Set("ce-id", ce.ID())
 			req.Header.Set("ce-subject", ce.Subject())
-			req.Header.Set("ce-time", ce.Time().Format(timeFmt))
+			req.Header.Set("ce-time", ce.Time().Format(time.RFC3339Nano))
 			req.Header.Set("ce-specversion", ce.SpecVersion())
 
 			if err := convertCloudEventToBackgroundRequest(req); err != nil {
@@ -801,7 +801,7 @@ func TestShouldConvertCloudEventToBackgroundRequest(t *testing.T) {
 				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
 				"subject": "objects/folder/Test.cs",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json"
 			  }`,
 			shouldConvert: true,
@@ -826,7 +826,7 @@ func TestShouldConvertCloudEventToBackgroundRequest(t *testing.T) {
 				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
 				"subject": "objects/folder/Test.cs",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json"
 			  }`,
 			shouldConvert: false,
@@ -838,7 +838,7 @@ func TestShouldConvertCloudEventToBackgroundRequest(t *testing.T) {
 				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
 				"subject": "objects/folder/Test.cs",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json"
 			  }`,
 			shouldConvert: false,
@@ -850,7 +850,7 @@ func TestShouldConvertCloudEventToBackgroundRequest(t *testing.T) {
 				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
 				"subject": "objects/folder/Test.cs",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json"
 			  }`,
 			shouldConvert: false,
@@ -861,7 +861,7 @@ func TestShouldConvertCloudEventToBackgroundRequest(t *testing.T) {
 				"specversion": "1.0",
 				"subject": "objects/folder/Test.cs",
 				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json"
 			  }`,
 			shouldConvert: false,
@@ -873,7 +873,7 @@ func TestShouldConvertCloudEventToBackgroundRequest(t *testing.T) {
 				"type": "google.cloud.storage.object.v1.finalized",
 				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
 				"subject": "objects/folder/Test.cs",
-				"time": "2020-09-29T11:32:00.000Z",
+				"time": "2020-09-29T11:32:00.123Z",
 				"datacontenttype": "application/json"
 			  }`,
 			shouldConvert: false,


### PR DESCRIPTION
Trailing zeros do not need to be included in RFC3339 timestamps.