### PR TITLE
test: add helper script for conformance tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ information on using pull requests.
 All code changes must be tested before they are merged.
 
 ### Unit Tests
+
 Run all unit tests with:
 
 ```commandline
@@ -40,8 +41,10 @@ go test -v -run TestSplitResource/firebaseauth.googleapis.com ./...
 ```
 
 ### Conformance Tests
+
 Run the [Functions Framework conformance tests](https://github.com/GoogleCloudPlatform/functions-framework-conformance) with:
-```
+
+```commandline
 ./run_conformance_tests.sh
 ```
 

--- a/run_conformance_tests.sh
+++ b/run_conformance_tests.sh
@@ -14,11 +14,11 @@
 # latest release.
 
 CLIENT_VERSION=$1
-if [ $CLIENT_VERSION ]
-then
+if [ $CLIENT_VERSION ]; then
     CLIENT_VERSION="@$CLIENT_VERSION"
 else
-    echo "Defaulting to latest client; use './run_conformance_tests vX.X.X' to specify a specific release version"
+    echo "Defaulting to latest client."
+    echo "Use './run_conformance_tests vX.X.X' to specify a specific release version."
     CLIENT_VERSION="@latest"
 fi
 
@@ -31,6 +31,7 @@ function print_header() {
 set -e
 
 print_header "INSTALLING CLIENT$CLIENT_VERSION"
+echo "Note: only works with Go 1.16+ by default, see run_conformance_tests.sh for more information."
 # Go install @version only works on go 1.16+, if using a lower Go version
 # replace command with:
 # go get github.com/GoogleCloudPlatform/functions-framework-conformance/client$CLIENT_VERSION && go install github.com/GoogleCloudPlatform/functions-framework-conformance/client


### PR DESCRIPTION
Use `./run_conformance_tests.sh` to run the conformance tests
 locally when developing.