### PR TITLE
feat: move declarative function API into `functions` package

### DIFF
--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"reflect"
@@ -109,20 +108,6 @@ func RegisterCloudEventFunctionContext(ctx context.Context, path string, fn func
 	return err
 }
 
-// Declaratively registers a HTTP function.
-func HTTP(name string, fn func(http.ResponseWriter, *http.Request)) {
-	if err := registry.RegisterHTTP(name, fn); err != nil {
-		log.Fatalf("failure to register function: %s", err)
-	}
-}
-
-// Declaratively registers a CloudEvent function.
-func CloudEvent(name string, fn func(context.Context, cloudevents.Event) error) {
-	if err := registry.RegisterCloudEvent(name, fn); err != nil {
-		log.Fatalf("failure to register function: %s", err)
-	}
-}
-
 // Start serves an HTTP server with registered function(s).
 func Start(port string) error {
 	// If FUNCTION_TARGET, try to start with that registered function
@@ -135,7 +120,7 @@ func Start(port string) error {
 	}
 
 	// Check if there's a registered function, and use if possible
-	if fn, ok := registry.GetRegisteredFunction(target); ok {
+	if fn, ok := registry.Default().GetRegisteredFunction(target); ok {
 		ctx := context.Background()
 		if fn.HTTPFn != nil {
 			server, err := wrapHTTPFunction("/", fn.HTTPFn)

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/GoogleCloudPlatform/functions-framework-go/internal/registry"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/go-cmp/cmp"
@@ -455,11 +456,11 @@ func TestDeclarativeFunctionHTTP(t *testing.T) {
 	}
 
 	// register functions
-	HTTP(funcName, func(w http.ResponseWriter, r *http.Request) {
+	functions.HTTP(funcName, func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "Hello World!")
 	})
 
-	if _, ok := registry.GetRegisteredFunction(funcName); !ok {
+	if _, ok := registry.Default().GetRegisteredFunction(funcName); !ok {
 		t.Fatalf("could not get registered function: %s", funcName)
 	}
 
@@ -480,9 +481,9 @@ func TestDeclarativeFunctionCloudEvent(t *testing.T) {
 	}
 
 	// register functions
-	CloudEvent(funcName, dummyCloudEvent)
+	functions.CloudEvent(funcName, dummyCloudEvent)
 
-	if _, ok := registry.GetRegisteredFunction(funcName); !ok {
+	if _, ok := registry.Default().GetRegisteredFunction(funcName); !ok {
 		t.Fatalf("could not get registered function: %s", funcName)
 	}
 

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -1,0 +1,24 @@
+package functions
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/functions-framework-go/internal/registry"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+// Declaratively registers a HTTP function.
+func HTTP(name string, fn func(http.ResponseWriter, *http.Request)) {
+	if err := registry.Default().RegisterHTTP(name, fn); err != nil {
+		log.Fatalf("failure to register function: %s", err)
+	}
+}
+
+// Declaratively registers a CloudEvent function.
+func CloudEvent(name string, fn func(context.Context, cloudevents.Event) error) {
+	if err := registry.Default().RegisterCloudEvent(name, fn); err != nil {
+		log.Fatalf("failure to register function: %s", err)
+	}
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -23,11 +23,12 @@ import (
 )
 
 func TestRegisterHTTP(t *testing.T) {
-	RegisterHTTP("httpfn", func(w http.ResponseWriter, r *http.Request) {
+	registry := New()
+	registry.RegisterHTTP("httpfn", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "Hello World!")
 	})
 
-	fn, ok := GetRegisteredFunction("httpfn")
+	fn, ok := registry.GetRegisteredFunction("httpfn")
 	if !ok {
 		t.Fatalf("Expected function to be registered")
 	}
@@ -37,11 +38,12 @@ func TestRegisterHTTP(t *testing.T) {
 }
 
 func TestRegisterCE(t *testing.T) {
-	RegisterCloudEvent("cefn", func(context.Context, cloudevents.Event) error {
+	registry := New()
+	registry.RegisterCloudEvent("cefn", func(context.Context, cloudevents.Event) error {
 		return nil
 	})
 
-	fn, ok := GetRegisteredFunction("cefn")
+	fn, ok := registry.GetRegisteredFunction("cefn")
 	if !ok {
 		t.Fatalf("Expected function to be registered")
 	}
@@ -51,17 +53,18 @@ func TestRegisterCE(t *testing.T) {
 }
 
 func TestRegisterMultipleFunctions(t *testing.T) {
-	if err := RegisterHTTP("multifn1", func(w http.ResponseWriter, r *http.Request) {
+	registry := New()
+	if err := registry.RegisterHTTP("multifn1", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "Hello World!")
 	}); err != nil {
 		t.Error("Expected \"multifn1\" function to be registered")
 	}
-	if err := RegisterHTTP("multifn2", func(w http.ResponseWriter, r *http.Request) {
+	if err := registry.RegisterHTTP("multifn2", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "Hello World 2!")
 	}); err != nil {
 		t.Error("Expected \"multifn2\" function to be registered")
 	}
-	if err := RegisterCloudEvent("multifn3", func(context.Context, cloudevents.Event) error {
+	if err := registry.RegisterCloudEvent("multifn3", func(context.Context, cloudevents.Event) error {
 		return nil
 	}); err != nil {
 		t.Error("Expected \"multifn3\" function to be registered")
@@ -69,13 +72,14 @@ func TestRegisterMultipleFunctions(t *testing.T) {
 }
 
 func TestRegisterMultipleFunctionsError(t *testing.T) {
-	if err := RegisterHTTP("samename", func(w http.ResponseWriter, r *http.Request) {
+	registry := New()
+	if err := registry.RegisterHTTP("samename", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "Hello World!")
 	}); err != nil {
 		t.Error("Expected no error registering function")
 	}
 
-	if err := RegisterHTTP("samename", func(w http.ResponseWriter, r *http.Request) {
+	if err := registry.RegisterHTTP("samename", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "Hello World 2!")
 	}); err == nil {
 		t.Error("Expected error registering function with same name")

--- a/testdata/conformance/function/function.go
+++ b/testdata/conformance/function/function.go
@@ -24,13 +24,19 @@ import (
 	"net/http"
 
 	"cloud.google.com/go/functions/metadata"
-	"github.com/GoogleCloudPlatform/functions-framework-go/funcframework"
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
 const (
 	outputFile = "function_output.json"
 )
+
+// Register declarative functions
+func init() {
+	functions.HTTP("declarativeHTTP", HTTP)
+	functions.CloudEvent("declarativeCloudEvent", CloudEvent)
+}
 
 // HTTP is a simple HTTP function that writes the request body to the response body.
 func HTTP(w http.ResponseWriter, r *http.Request) {
@@ -80,10 +86,4 @@ func CloudEvent(ctx context.Context, ce cloudevents.Event) error {
 	}
 
 	return nil
-}
-
-// Register declarative functions
-func init() {
-	funcframework.HTTP("declarativeHTTP", HTTP)
-	funcframework.CloudEvent("declarativeCloudEvent", CloudEvent)
 }


### PR DESCRIPTION
This separates the encouraged, declarative function signature API away
from the `funcframework` package, which should primarily be used for local testing going forward.

```go
package fn

import (
    "fmt"
    "github.com/GoogleCloudPlatform/functions-framework-go/functions"
)

func init() {
    functions.HTTP("declarativeHTTP", myHTTPFunc)
    functions.CloudEvent("declarativeCloudEvent", myCloudEventFunc)
}

func myHTTPFunc(w http.ResponseWriter, r *http.Request) {
    fmt.Println("HTTP function")
}

func myCloudEventFunc(ctx context.Context, ce cloudevents.Event) error {
    fmt.Println("CloudEvent function")
    return nil
}
```
Also, refactor some of the internal/registry implementation so it's more
obvious that `functions` package and `funcframework` package are sharing
the same registry.