### PR TITLE
docs: fix CloudEvent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ import (
 )
 
 func init() {
-	functions.CloudEvent("CloudEventFunc", CloudEvent)
+	functions.CloudEvent("CloudEventFunc", cloudEventFunc)
 }
 
 func cloudEventFunc(ctx context.Context, e cloudevents.Event) error {


### PR DESCRIPTION
The current CloudEvent example does not work:

```
❯ go run cmd/main.go
# example.com/hello
./functions.go:12:41: undefined: cloudEvent
```