### PR TITLE
ci: test go118

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.13, 1.14, 1.15, 1.16]
+        go-version: [1.13, 1.16, 1.18]
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [1.13, 1.14, 1.15, 1.16]
+        go: [1.13, 1.16, 1.18]
         os: [ubuntu-latest, macos-latest] # windows-latest doesn't support find -wholename
     steps:
     - name: Checkout code

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [1.13, 1.14, 1.15, 1.16]
+        go: [1.13, 1.16, 1.18]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: Checkout code


### PR DESCRIPTION
- Test 1.18
- Remove older versions that aren't used, as our matrix is large.