### PR TITLE
fix: log CloudEvent function errors to stderr

### DIFF
--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -292,10 +292,10 @@ func TestEventFunction(t *testing.T) {
 			origStderrPipe := os.Stderr
 			r, w, _ := os.Pipe()
 			os.Stderr = w
-			t.Cleanup(func() { os.Stderr = origStderrPipe })
+			defer func() { os.Stderr = origStderrPipe }()
 
 			srv := httptest.NewServer(h)
-			t.Cleanup(srv.Close)
+			defer srv.Close()
 
 			req, err := http.NewRequest("POST", srv.URL, bytes.NewBuffer(tc.body))
 			if err != nil {
@@ -528,10 +528,10 @@ func TestCloudEventFunction(t *testing.T) {
 			origStderrPipe := os.Stderr
 			r, w, _ := os.Pipe()
 			os.Stderr = w
-			t.Cleanup(func() { os.Stderr = origStderrPipe })
+			defer func() { os.Stderr = origStderrPipe }()
 
 			srv := httptest.NewServer(h)
-			t.Cleanup(srv.Close)
+			defer srv.Close()
 
 			req, err := http.NewRequest("POST", srv.URL, bytes.NewBuffer(tc.body))
 			if err != nil {


### PR DESCRIPTION
CloudEvent functions currently return 500 when an error is returned, but
do not do anything with the error message. This logs the error message
to stderr so it is not lost.

Unlike Background Functions, the error message is NOT included in the
response body though.

Also, add fields for checking stderr to the unit tests.