### PR TITLE
fix: Allow registering multiple functions with one server for local testing.

### DIFF
--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -82,28 +82,22 @@ func RegisterEventFunction(path string, fn interface{}) {
 
 // RegisterHTTPFunctionContext registers fn as an HTTP function.
 func RegisterHTTPFunctionContext(ctx context.Context, path string, fn func(http.ResponseWriter, *http.Request)) error {
-	if err := registry.Default().RegisterHTTP(path, fn, registry.WithPath(path)); err != nil {
-		return fmt.Errorf("failed to register function at path %s: %s", path, err)
-	}
-	return nil
+	funcName := fmt.Sprintf("function_at_path_%q", path)
+	return registry.Default().RegisterHTTP(funcName, fn, registry.WithPath(path))
 }
 
 // RegisterEventFunctionContext registers fn as an event function. The function must have two arguments, a
 // context.Context and a struct type depending on the event, and return an error. If fn has the
 // wrong signature, RegisterEventFunction returns an error.
 func RegisterEventFunctionContext(ctx context.Context, path string, fn interface{}) error {
-	if err := registry.Default().RegisterEvent(path, fn, registry.WithPath(path)); err != nil {
-		return fmt.Errorf("failed to register function at path %s: %s", path, err)
-	}
-	return nil
+	funcName := fmt.Sprintf("function_at_path_%q", path)
+	return registry.Default().RegisterEvent(funcName, fn, registry.WithPath(path))
 }
 
 // RegisterCloudEventFunctionContext registers fn as an cloudevent function.
 func RegisterCloudEventFunctionContext(ctx context.Context, path string, fn func(context.Context, cloudevents.Event) error) error {
-	if err := registry.Default().RegisterCloudEvent(path, fn, registry.WithPath(path)); err != nil {
-		return fmt.Errorf("failed to register function at path %s: %s", path, err)
-	}
-	return nil
+	funcName := fmt.Sprintf("function_at_path_%q", path)
+	return registry.Default().RegisterCloudEvent(funcName, fn, registry.WithPath(path))
 }
 
 // Start serves an HTTP server with registered function(s).

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -611,9 +611,15 @@ func TestDeclarativeFunctionHTTP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not make HTTP GET request to function: %s", err)
 	}
+<<<<<<< HEAD
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("io.ReadAll: %v", err)
+=======
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ioutil.ReadAll: %v", err)
+>>>>>>> 97bd983 (Allow registering multiple functions with one server for local testing.)
 	}
 	if got := strings.TrimSpace(string(body)); got != funcResp {
 		t.Errorf("unexpected http response: got %q; want: %q", got, funcResp)
@@ -705,9 +711,9 @@ func TestServeMultipleFunctions(t *testing.T) {
 		if err != nil {
 			t.Fatalf("could not make HTTP GET request to function: %s", err)
 		}
-		body, err := io.ReadAll(resp.Body)
+		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			t.Fatalf("io.ReadAll: %v", err)
+			t.Fatalf("ioutil.ReadAll: %v", err)
 		}
 		if got := strings.TrimSpace(string(body)); got != f.wantResp {
 			t.Errorf("unexpected http response: got %q; want: %q", got, f.wantResp)

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -611,15 +610,10 @@ func TestDeclarativeFunctionHTTP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not make HTTP GET request to function: %s", err)
 	}
-<<<<<<< HEAD
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("io.ReadAll: %v", err)
-=======
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("ioutil.ReadAll: %v", err)
->>>>>>> 97bd983 (Allow registering multiple functions with one server for local testing.)
 	}
 	if got := strings.TrimSpace(string(body)); got != funcResp {
 		t.Errorf("unexpected http response: got %q; want: %q", got, funcResp)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -12,8 +12,19 @@ import (
 // registered with the registry.
 type RegisteredFunction struct {
 	Name         string                                         // The name of the function
+	Path         string                                         // The serving path of the function
 	CloudEventFn func(context.Context, cloudevents.Event) error // Optional: The user's CloudEvent function
 	HTTPFn       func(http.ResponseWriter, *http.Request)       // Optional: The user's HTTP function
+	EventFn      interface{}                                    // Optional: The user's Event function
+}
+
+// Option is
+type Option func(*RegisteredFunction)
+
+func WithPath(path string) Option {
+	return func(fn *RegisteredFunction) {
+		fn.Path = path
+	}
 }
 
 // Registry is a registry of functions.
@@ -35,28 +46,59 @@ func New() *Registry {
 }
 
 // RegisterHTTP a HTTP function with a given name
-func (r *Registry) RegisterHTTP(name string, fn func(http.ResponseWriter, *http.Request)) error {
+func (r *Registry) RegisterHTTP(name string, fn func(http.ResponseWriter, *http.Request), options ...Option) error {
 	if _, ok := r.functions[name]; ok {
 		return fmt.Errorf("function name already registered: %s", name)
 	}
-	r.functions[name] = RegisteredFunction{
+	function := RegisteredFunction{
 		Name:         name,
+		Path:         "/" + name,
 		CloudEventFn: nil,
 		HTTPFn:       fn,
+		EventFn:      nil,
 	}
+	for _, o := range options {
+		o(&function)
+	}
+	r.functions[name] = function
 	return nil
 }
 
 // RegistryCloudEvent a CloudEvent function with a given name
-func (r *Registry) RegisterCloudEvent(name string, fn func(context.Context, cloudevents.Event) error) error {
+func (r *Registry) RegisterCloudEvent(name string, fn func(context.Context, cloudevents.Event) error, options ...Option) error {
 	if _, ok := r.functions[name]; ok {
 		return fmt.Errorf("function name already registered: %s", name)
 	}
-	r.functions[name] = RegisteredFunction{
+	function := RegisteredFunction{
 		Name:         name,
+		Path:         "/" + name,
 		CloudEventFn: fn,
 		HTTPFn:       nil,
+		EventFn:      nil,
 	}
+	for _, o := range options {
+		o(&function)
+	}
+	r.functions[name] = function
+	return nil
+}
+
+// RegistryCloudEvent a Event function with a given name
+func (r *Registry) RegisterEvent(name string, fn interface{}, options ...Option) error {
+	if _, ok := r.functions[name]; ok {
+		return fmt.Errorf("function name already registered: %s", name)
+	}
+	function := RegisteredFunction{
+		Name:         name,
+		Path:         "/" + name,
+		CloudEventFn: nil,
+		HTTPFn:       nil,
+		EventFn:      fn,
+	}
+	for _, o := range options {
+		o(&function)
+	}
+	r.functions[name] = function
 	return nil
 }
 
@@ -66,7 +108,7 @@ func (r *Registry) GetRegisteredFunction(name string) (RegisteredFunction, bool)
 	return fn, ok
 }
 
-// GetAllRegisteredFunction returns all the registered functions.
-func (r *Registry) GetAllRegisteredFunction() map[string]RegisteredFunction {
+// GetAllFunctions returns all the registered functions.
+func (r *Registry) GetAllFunctions() map[string]RegisteredFunction {
 	return r.functions
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -65,3 +65,8 @@ func (r *Registry) GetRegisteredFunction(name string) (RegisteredFunction, bool)
 	fn, ok := r.functions[name]
 	return fn, ok
 }
+
+// GetAllRegisteredFunction returns all the registered functions.
+func (r *Registry) GetAllRegisteredFunction() map[string]RegisteredFunction {
+	return r.functions
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -18,7 +18,7 @@ type RegisteredFunction struct {
 	EventFn      interface{}                                    // Optional: The user's Event function
 }
 
-// Option is
+// Option is an option used when registering a function.
 type Option func(*RegisteredFunction)
 
 func WithPath(path string) Option {
@@ -48,7 +48,7 @@ func New() *Registry {
 // RegisterHTTP a HTTP function with a given name
 func (r *Registry) RegisterHTTP(name string, fn func(http.ResponseWriter, *http.Request), options ...Option) error {
 	if _, ok := r.functions[name]; ok {
-		return fmt.Errorf("function name already registered: %s", name)
+		return fmt.Errorf("function name already registered: %q", name)
 	}
 	function := RegisteredFunction{
 		Name:         name,
@@ -67,7 +67,7 @@ func (r *Registry) RegisterHTTP(name string, fn func(http.ResponseWriter, *http.
 // RegistryCloudEvent a CloudEvent function with a given name
 func (r *Registry) RegisterCloudEvent(name string, fn func(context.Context, cloudevents.Event) error, options ...Option) error {
 	if _, ok := r.functions[name]; ok {
-		return fmt.Errorf("function name already registered: %s", name)
+		return fmt.Errorf("function name already registered: %q", name)
 	}
 	function := RegisteredFunction{
 		Name:         name,
@@ -86,7 +86,7 @@ func (r *Registry) RegisterCloudEvent(name string, fn func(context.Context, clou
 // RegistryCloudEvent a Event function with a given name
 func (r *Registry) RegisterEvent(name string, fn interface{}, options ...Option) error {
 	if _, ok := r.functions[name]; ok {
-		return fmt.Errorf("function name already registered: %s", name)
+		return fmt.Errorf("function name already registered: %q", name)
 	}
 	function := RegisteredFunction{
 		Name:         name,
@@ -111,4 +111,9 @@ func (r *Registry) GetRegisteredFunction(name string) (RegisteredFunction, bool)
 // GetAllFunctions returns all the registered functions.
 func (r *Registry) GetAllFunctions() map[string]RegisteredFunction {
 	return r.functions
+}
+
+// DeleteRegisteredFunction deletes a registered function.
+func (r *Registry) DeleteRegisteredFunction(name string) {
+	delete(r.functions, name)
 }


### PR DESCRIPTION
There are two ways to test multiple functions within one server. 

1. Declaratively register multiple functions (e.g. calling `functions.HTTP()`) and run `go run cmd/main.go` without setting the env var `FUNCTION_TARGET`. In this case, all registered functions will be served  at "/{func_name}".
2. Manually register the handers (e.g. calling `funcframework.RegisterHTTPFunctionContext()`)  and run `go run cmd/main.go` without setting the env var `FUNCTION_TARGET`. In this case, only the registered handlers will be served at the user defined path.

Closes #109 