### PR TITLE
fix: remove obsolete blank prints

### DIFF
--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -140,8 +140,8 @@ func initServer() (*http.ServeMux, error) {
 
 func wrapFunction(fn registry.RegisteredFunction) (http.Handler, error) {
 	// Check if we have a function resource set, and if so, log progress.
-	if os.Getenv("K_SERVICE") == "" {
-		fmt.Printf("Serving function %s\n", fn.Name)
+	if os.Getenv("FUNCTION_TARGET") == "" {
+		fmt.Printf("Serving function: %q", fn.Name)
 	}
 
 	if fn.HTTPFn != nil {
@@ -169,11 +169,7 @@ func wrapFunction(fn registry.RegisteredFunction) (http.Handler, error) {
 func wrapHTTPFunction(fn func(http.ResponseWriter, *http.Request)) (http.Handler, error) {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// TODO(b/111823046): Remove following once Cloud Functions does not need flushing the logs anymore.
-		if os.Getenv("K_SERVICE") != "" {
-			// Force flush of logs after every function trigger when running on GCF.
-			defer fmt.Println()
-			defer fmt.Fprintln(os.Stderr)
-		}
+
 		defer recoverPanic(w, "user function execution")
 		fn(w, r)
 	}), nil
@@ -185,12 +181,6 @@ func wrapEventFunction(fn interface{}) (http.Handler, error) {
 		return nil, err
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if os.Getenv("K_SERVICE") != "" {
-			// Force flush of logs after every function trigger when running on GCF.
-			defer fmt.Println()
-			defer fmt.Fprintln(os.Stderr)
-		}
-
 		if shouldConvertCloudEventToBackgroundRequest(r) {
 			if err := convertCloudEventToBackgroundRequest(r); err != nil {
 				writeHTTPErrorResponse(w, http.StatusBadRequest, crashStatus, fmt.Sprintf("error converting CloudEvent to Background Event: %v", err))
@@ -294,13 +284,6 @@ func writeHTTPErrorResponse(w http.ResponseWriter, statusCode int, status, msg s
 		msg += "\n"
 	}
 	fmt.Fprint(os.Stderr, msg)
-
-	// Flush stdout and stderr when running on GCF. This must be done before writing
-	// the HTTP response in order for all logs to appear in Stackdriver.
-	if os.Getenv("K_SERVICE") != "" {
-		fmt.Println()
-		fmt.Fprintln(os.Stderr)
-	}
 
 	w.Header().Set(functionStatusHeader, status)
 	w.WriteHeader(statusCode)

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -168,8 +168,6 @@ func wrapFunction(fn registry.RegisteredFunction) (http.Handler, error) {
 
 func wrapHTTPFunction(fn func(http.ResponseWriter, *http.Request)) (http.Handler, error) {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// TODO(b/111823046): Remove following once Cloud Functions does not need flushing the logs anymore.
-
 		defer recoverPanic(w, "user function execution")
 		fn(w, r)
 	}), nil


### PR DESCRIPTION
These blank lines were included to force-flush logs on previous versions of GCF, but are no longer needed because there have been changes to GCF log handling since then.