### PR TITLE
feat: rename initServer to NewServeMux

### DIFF
--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -102,14 +102,15 @@ func RegisterCloudEventFunctionContext(ctx context.Context, path string, fn func
 
 // Start serves an HTTP server with registered function(s).
 func Start(port string) error {
-	server, err := initServer()
+	server, err := NewServeMux()
 	if err != nil {
 		return err
 	}
 	return http.ListenAndServe(":"+port, server)
 }
 
-func initServer() (*http.ServeMux, error) {
+// NewServeMux constructs an HTTP ServeMux that serves the configured function target.
+func NewServeMux() (*http.ServeMux, error) {
 	server := http.NewServeMux()
 
 	// If FUNCTION_TARGET is set, only serve this target function at path "/".

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -65,9 +65,9 @@ func TestRegisterHTTPFunctionContext(t *testing.T) {
 				t.Fatalf("RegisterHTTPFunctionContext(): %v", err)
 			}
 
-			server, err := initServer()
+			server, err := NewServeMux()
 			if err != nil {
-				t.Fatalf("initServer(): %v", err)
+				t.Fatalf("NewServeMux(): %v", err)
 			}
 			srv := httptest.NewServer(server)
 			defer srv.Close()
@@ -307,9 +307,9 @@ func TestRegisterEventFunctionContext(t *testing.T) {
 			os.Stderr = w
 			defer func() { os.Stderr = origStderrPipe }()
 
-			server, err := initServer()
+			server, err := NewServeMux()
 			if err != nil {
-				t.Fatalf("initServer(): %v", err)
+				t.Fatalf("NewServeMux(): %v", err)
 			}
 			srv := httptest.NewServer(server)
 			defer srv.Close()
@@ -551,9 +551,9 @@ func TestRegisterCloudEventFunctionContext(t *testing.T) {
 			os.Stderr = w
 			defer func() { os.Stderr = origStderrPipe }()
 
-			server, err := initServer()
+			server, err := NewServeMux()
 			if err != nil {
-				t.Fatalf("initServer(): %v", err)
+				t.Fatalf("NewServeMux(): %v", err)
 			}
 			srv := httptest.NewServer(server)
 			defer srv.Close()
@@ -628,9 +628,9 @@ func TestDeclarativeFunctionHTTP(t *testing.T) {
 		t.Fatalf("could not get registered function: %q", funcName)
 	}
 
-	server, err := initServer()
+	server, err := NewServeMux()
 	if err != nil {
-		t.Fatalf("initServer(): %v", err)
+		t.Fatalf("NewServeMux(): %v", err)
 	}
 	srv := httptest.NewServer(server)
 	defer srv.Close()
@@ -665,9 +665,9 @@ func TestDeclarativeFunctionCloudEvent(t *testing.T) {
 		t.Fatalf("could not get registered function: %s", funcName)
 	}
 
-	server, err := initServer()
+	server, err := NewServeMux()
 	if err != nil {
-		t.Fatalf("initServer(): %v", err)
+		t.Fatalf("NewServeMux(): %v", err)
 	}
 	srv := httptest.NewServer(server)
 	defer srv.Close()
@@ -723,9 +723,9 @@ func TestServeMultipleFunctions(t *testing.T) {
 		}
 	}
 
-	server, err := initServer()
+	server, err := NewServeMux()
 	if err != nil {
-		t.Fatalf("initServer(): %v", err)
+		t.Fatalf("NewServeMux(): %v", err)
 	}
 	srv := httptest.NewServer(server)
 	defer srv.Close()


### PR DESCRIPTION
I'm working on some cloud functions that I'd like to write unit-tests for where the unit-test spins up the cloud function locally and makes some HTTP requests against it.

I would use `funcframework.Start` for this, but there's no way to shut down the server once it's started, so the tests conflict with one another on the port, and the goroutines used to start the servers stay running until the test process exits.

A simple way to fix this is to be able to pass a context into `funcframework.Start` so I can cancel the context when I'm done with the server. That's what this PR is for.

For reverse-compatibility reasons, I added a new function named `StartContext` rather than modifying the `Start` function.