### PR TITLE
feat: Allow registering multiple functions with one server for local testing

### DIFF
--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -39,10 +39,6 @@ const (
 	fnErrorMessageStderrTmpl = "Function error: %v"
 )
 
-var (
-	handler http.Handler
-)
-
 // recoverPanic recovers from a panic in a consistent manner. panicSrc should
 // describe what was happening when the panic was encountered, for example
 // "user function execution". w is an http.ResponseWriter to write a generic
@@ -86,85 +82,110 @@ func RegisterEventFunction(path string, fn interface{}) {
 
 // RegisterHTTPFunctionContext registers fn as an HTTP function.
 func RegisterHTTPFunctionContext(ctx context.Context, path string, fn func(http.ResponseWriter, *http.Request)) error {
-	server, err := wrapHTTPFunction(path, fn)
-	if err == nil {
-		handler = server
-	}
-	return err
+	funcName := fmt.Sprintf("function_at_path_%q", path)
+	return registry.Default().RegisterHTTP(funcName, fn, registry.WithPath(path), registry.WithLegacy())
 }
 
 // RegisterEventFunctionContext registers fn as an event function. The function must have two arguments, a
 // context.Context and a struct type depending on the event, and return an error. If fn has the
 // wrong signature, RegisterEventFunction returns an error.
 func RegisterEventFunctionContext(ctx context.Context, path string, fn interface{}) error {
-	server, err := wrapEventFunction(path, fn)
-	if err == nil {
-		handler = server
-	}
-	return err
+	funcName := fmt.Sprintf("function_at_path_%q", path)
+	return registry.Default().RegisterEvent(funcName, fn, registry.WithPath(path), registry.WithLegacy())
 }
 
 // RegisterCloudEventFunctionContext registers fn as an cloudevent function.
 func RegisterCloudEventFunctionContext(ctx context.Context, path string, fn func(context.Context, cloudevents.Event) error) error {
-	server, err := wrapCloudEventFunction(ctx, path, fn)
-	if err == nil {
-		handler = server
-	}
-	return err
+	funcName := fmt.Sprintf("function_at_path_%q", path)
+	return registry.Default().RegisterCloudEvent(funcName, fn, registry.WithPath(path), registry.WithLegacy())
 }
 
 // Start serves an HTTP server with registered function(s).
 func Start(port string) error {
-	// If FUNCTION_TARGET, try to start with that registered function
-	// If not set, assume non-declarative functions.
-	target := os.Getenv("FUNCTION_TARGET")
-
-	// Check if we have a function resource set, and if so, log progress.
-	if os.Getenv("K_SERVICE") == "" {
-		fmt.Printf("Serving function: %q", target)
+	server, err := initServer()
+	if err != nil {
+		return err
 	}
-
-	// Check if there's a registered function, and use if possible
-	if fn, ok := registry.Default().GetRegisteredFunction(target); ok {
-		ctx := context.Background()
-		if fn.HTTPFn != nil {
-			server, err := wrapHTTPFunction("/", fn.HTTPFn)
-			if err != nil {
-				return fmt.Errorf("unexpected error in registerHTTPFunction: %v", err)
-			}
-			handler = server
-		} else if fn.CloudEventFn != nil {
-			server, err := wrapCloudEventFunction(ctx, "/", fn.CloudEventFn)
-			if err != nil {
-				return fmt.Errorf("unexpected error in registerCloudEventFunction: %v", err)
-			}
-			handler = server
-		}
-	}
-
-	if handler == nil {
-		return fmt.Errorf("no matching function found with name: %q", target)
-	}
-
-	return http.ListenAndServe(":"+port, handler)
+	return http.ListenAndServe(":"+port, server)
 }
 
-func wrapHTTPFunction(path string, fn func(http.ResponseWriter, *http.Request)) (http.Handler, error) {
-	h := http.NewServeMux()
-	h.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+func initServer() (*http.ServeMux, error) {
+	server := http.NewServeMux()
+
+	// If FUNCTION_TARGET is set, only serve this target function at path "/".
+	// If not set, serve all functions at the registered paths.
+	if target := os.Getenv("FUNCTION_TARGET"); len(target) > 0 {
+		var targetFn registry.RegisteredFunction
+
+		fn, ok := registry.Default().GetRegisteredFunction(target)
+		if ok {
+			targetFn = fn
+		} else if lastLegacyFn, ok := registry.Default().GetLastLegacyFunction(); ok {
+			targetFn = lastLegacyFn
+		} else {
+			return nil, fmt.Errorf("no matching function found with name: %q", target)
+		}
+
+		h, err := wrapFunction(targetFn)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serve function %q: %v", target, err)
+		}
+		server.Handle("/", h)
+		return server, nil
+	}
+
+	fns := registry.Default().GetAllFunctions()
+	for funcName, fn := range fns {
+		h, err := wrapFunction(fn)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serve function %q: %v", funcName, err)
+		}
+		server.Handle(fn.Path, h)
+	}
+	return server, nil
+}
+
+func wrapFunction(fn registry.RegisteredFunction) (http.Handler, error) {
+	// Check if we have a function resource set, and if so, log progress.
+	if os.Getenv("FUNCTION_TARGET") == "" {
+		fmt.Printf("Serving function: %q", fn.Name)
+	}
+
+	if fn.HTTPFn != nil {
+		handler, err := wrapHTTPFunction(fn.HTTPFn)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected error in wrapHTTPFunction: %v", err)
+		}
+		return handler, nil
+	} else if fn.CloudEventFn != nil {
+		handler, err := wrapCloudEventFunction(context.Background(), fn.CloudEventFn)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected error in wrapCloudEventFunction: %v", err)
+		}
+		return handler, nil
+	} else if fn.EventFn != nil {
+		handler, err := wrapEventFunction(fn.EventFn)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected error in wrapEventFunction: %v", err)
+		}
+		return handler, nil
+	}
+	return nil, fmt.Errorf("missing function entry in %v", fn)
+}
+
+func wrapHTTPFunction(fn func(http.ResponseWriter, *http.Request)) (http.Handler, error) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer recoverPanic(w, "user function execution")
 		fn(w, r)
-	})
-	return h, nil
+	}), nil
 }
 
-func wrapEventFunction(path string, fn interface{}) (http.Handler, error) {
-	h := http.NewServeMux()
+func wrapEventFunction(fn interface{}) (http.Handler, error) {
 	err := validateEventFunction(fn)
 	if err != nil {
 		return nil, err
 	}
-	h.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if shouldConvertCloudEventToBackgroundRequest(r) {
 			if err := convertCloudEventToBackgroundRequest(r); err != nil {
 				writeHTTPErrorResponse(w, http.StatusBadRequest, crashStatus, fmt.Sprintf("error converting CloudEvent to Background Event: %v", err))
@@ -172,11 +193,10 @@ func wrapEventFunction(path string, fn interface{}) (http.Handler, error) {
 		}
 
 		handleEventFunction(w, r, fn)
-	})
-	return h, nil
+	}), nil
 }
 
-func wrapCloudEventFunction(ctx context.Context, path string, fn func(context.Context, cloudevents.Event) error) (http.Handler, error) {
+func wrapCloudEventFunction(ctx context.Context, fn func(context.Context, cloudevents.Event) error) (http.Handler, error) {
 	p, err := cloudevents.NewHTTP()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create protocol: %v", err)

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -32,22 +32,35 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestHTTPFunction(t *testing.T) {
+func TestRegisterHTTPFunctionContext(t *testing.T) {
 	tests := []struct {
 		name       string
+		path       string
 		fn         func(w http.ResponseWriter, r *http.Request)
+		target     string
 		wantStatus int // defaults to http.StatusOK
 		wantResp   string
 	}{
 		{
 			name: "helloworld",
+			path: "/TestRegisterHTTPFunctionContext_helloworld",
 			fn: func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprint(w, "Hello World!")
 			},
 			wantResp: "Hello World!",
 		},
 		{
+			name: "FUNCTION_TARGET defined",
+			path: "/TestRegisterHTTPFunctionContext_target",
+			fn: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, "Hello World!")
+			},
+			target:   "helloworld",
+			wantResp: "Hello World!",
+		},
+		{
 			name: "panic in function",
+			path: "/TestRegisterHTTPFunctionContext_panic",
 			fn: func(w http.ResponseWriter, r *http.Request) {
 				panic("intentional panic for test")
 			},
@@ -58,16 +71,23 @@ func TestHTTPFunction(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			h, err := wrapHTTPFunction("/", tc.fn)
-			defer func() { handler = nil }()
-			if err != nil {
-				t.Fatalf("registerHTTPFunction(): %v", err)
+			if len(tc.target) > 0 {
+				os.Setenv("FUNCTION_TARGET", tc.target)
+				defer os.Unsetenv("FUNCTION_TARGET")
 			}
 
-			srv := httptest.NewServer(h)
+			if err := RegisterHTTPFunctionContext(context.Background(), tc.path, tc.fn); err != nil {
+				t.Fatalf("RegisterHTTPFunctionContext(): %v", err)
+			}
+
+			server, err := initServer()
+			if err != nil {
+				t.Fatalf("initServer(): %v", err)
+			}
+			srv := httptest.NewServer(server)
 			defer srv.Close()
 
-			resp, err := http.Get(srv.URL)
+			resp, err := http.Get(srv.URL + tc.path)
 			if err != nil {
 				t.Fatalf("http.Get: %v", err)
 			}
@@ -76,7 +96,7 @@ func TestHTTPFunction(t *testing.T) {
 				tc.wantStatus = http.StatusOK
 			}
 			if resp.StatusCode != tc.wantStatus {
-				t.Errorf("TestHTTPFunction status code: got %d, want: %d", resp.StatusCode, tc.wantStatus)
+				t.Errorf("unexpected status code: got %d, want: %d", resp.StatusCode, tc.wantStatus)
 			}
 
 			defer resp.Body.Close()
@@ -101,11 +121,13 @@ type eventData struct {
 	Data string `json:"data"`
 }
 
-func TestEventFunction(t *testing.T) {
+func TestRegisterEventFunctionContext(t *testing.T) {
 	var tests = []struct {
 		name       string
+		path       string
 		body       []byte
 		fn         interface{}
+		target     string
 		status     int
 		header     string
 		ceHeaders  map[string]string
@@ -114,6 +136,7 @@ func TestEventFunction(t *testing.T) {
 	}{
 		{
 			name: "valid function",
+			path: "/TestRegisterEventFunctionContext_valid",
 			body: []byte(`{"id": 12345,"name": "custom"}`),
 			fn: func(c context.Context, s customStruct) error {
 				if s.ID != 12345 {
@@ -128,7 +151,25 @@ func TestEventFunction(t *testing.T) {
 			header: "",
 		},
 		{
+			name: "FUNCTION_TARGET defined",
+			path: "/TestRegisterEventFunctionContext_target",
+			body: []byte(`{"id": 12345,"name": "custom"}`),
+			fn: func(c context.Context, s customStruct) error {
+				if s.ID != 12345 {
+					return fmt.Errorf("expected id=12345, got %d", s.ID)
+				}
+				if s.Name != "custom" {
+					return fmt.Errorf("TestEventFunction(valid function): got name=%s, want name=\"custom\"", s.Name)
+				}
+				return nil
+			},
+			target: "target",
+			status: http.StatusOK,
+			header: "",
+		},
+		{
 			name: "incorrect type",
+			path: "/TestRegisterEventFunctionContext_incorrect",
 			body: []byte(`{"id": 12345,"name": 123}`),
 			fn: func(c context.Context, s customStruct) error {
 				return nil
@@ -138,6 +179,7 @@ func TestEventFunction(t *testing.T) {
 		},
 		{
 			name: "erroring function",
+			path: "/TestRegisterEventFunctionContext_erroring",
 			body: []byte(`{"id": 12345,"name": "custom"}`),
 			fn: func(c context.Context, s customStruct) error {
 				return fmt.Errorf("TestEventFunction(erroring function): this error should fire")
@@ -149,6 +191,7 @@ func TestEventFunction(t *testing.T) {
 		},
 		{
 			name: "panicking function",
+			path: "/TestRegisterEventFunctionContext_panicking",
 			body: []byte(`{"id": 12345,"name": "custom"}`),
 			fn: func(c context.Context, s customStruct) error {
 				panic("intential panic for test")
@@ -159,6 +202,7 @@ func TestEventFunction(t *testing.T) {
 		},
 		{
 			name: "pubsub event",
+			path: "/TestRegisterEventFunctionContext_pubsub1",
 			body: []byte(`{
 				"context": {
 					"eventId": "1234567",
@@ -187,6 +231,7 @@ func TestEventFunction(t *testing.T) {
 		},
 		{
 			name: "pubsub legacy event",
+			path: "/TestRegisterEventFunctionContext_pubsub2",
 			body: []byte(`{
 				"eventId": "1234567",
 				"timestamp": "2019-11-04T23:01:10.112Z",
@@ -213,6 +258,7 @@ func TestEventFunction(t *testing.T) {
 		},
 		{
 			name: "cloudevent",
+			path: "/TestRegisterEventFunctionContext_cloudevent",
 			body: []byte(`{
 				"data": {
 				  "bucket": "some-bucket",
@@ -283,9 +329,13 @@ func TestEventFunction(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			h, err := wrapEventFunction("/", tc.fn)
-			if err != nil {
-				t.Fatalf("registerEventFunction(): %v", err)
+			if len(tc.target) > 0 {
+				os.Setenv("FUNCTION_TARGET", tc.target)
+				defer os.Unsetenv("FUNCTION_TARGET")
+			}
+
+			if err := RegisterEventFunctionContext(context.Background(), tc.path, tc.fn); err != nil {
+				t.Fatalf("RegisterEventFunctionContext(): %v", err)
 			}
 
 			// Capture stderr for the duration of the test case. This includes
@@ -295,10 +345,14 @@ func TestEventFunction(t *testing.T) {
 			os.Stderr = w
 			defer func() { os.Stderr = origStderrPipe }()
 
-			srv := httptest.NewServer(h)
+			server, err := initServer()
+			if err != nil {
+				t.Fatalf("initServer(): %v", err)
+			}
+			srv := httptest.NewServer(server)
 			defer srv.Close()
 
-			req, err := http.NewRequest("POST", srv.URL, bytes.NewBuffer(tc.body))
+			req, err := http.NewRequest("POST", srv.URL+tc.path, bytes.NewBuffer(tc.body))
 			if err != nil {
 				t.Fatalf("error creating HTTP request for test: %v", err)
 			}
@@ -350,7 +404,7 @@ func TestEventFunction(t *testing.T) {
 	}
 }
 
-func TestCloudEventFunction(t *testing.T) {
+func TestRegisterCloudEventFunctionContext(t *testing.T) {
 	cloudeventsJSON := []byte(`{
 		"specversion" : "1.0",
 		"type" : "com.github.pull.create",
@@ -370,8 +424,10 @@ func TestCloudEventFunction(t *testing.T) {
 
 	var tests = []struct {
 		name       string
+		path       string
 		body       []byte
 		fn         func(context.Context, cloudevents.Event) error
+		target 	   string
 		status     int
 		header     string
 		ceHeaders  map[string]string
@@ -380,6 +436,7 @@ func TestCloudEventFunction(t *testing.T) {
 	}{
 		{
 			name: "binary cloudevent",
+			path: "/TestRegisterCloudEventFunctionContext_binary",
 			body: []byte("<much wow=\"xml\"/>"),
 			fn: func(ctx context.Context, e cloudevents.Event) error {
 				if e.String() != testCE.String() {
@@ -402,6 +459,7 @@ func TestCloudEventFunction(t *testing.T) {
 		},
 		{
 			name: "structured cloudevent",
+			path: "/TestRegisterCloudEventFunctionContext_structured",
 			body: cloudeventsJSON,
 			fn: func(ctx context.Context, e cloudevents.Event) error {
 				if e.String() != testCE.String() {
@@ -416,7 +474,25 @@ func TestCloudEventFunction(t *testing.T) {
 			},
 		},
 		{
+			name: "FUNCTION_TARGET defined",
+			path: "/TestRegisterCloudEventFunctionContext_target",
+			body: cloudeventsJSON,
+			fn: func(ctx context.Context, e cloudevents.Event) error {
+				if e.String() != testCE.String() {
+					return fmt.Errorf("TestCloudEventFunction(structured cloudevent): got: %v, want: %v", e, testCE)
+				}
+				return nil
+			},
+			target: "target",
+			status: http.StatusOK,
+			header: "",
+			ceHeaders: map[string]string{
+				"Content-Type": "application/cloudevents+json",
+			},
+		},
+		{
 			name: "background event",
+			path: "/TestRegisterCloudEventFunctionContext_background",
 			body: []byte(`{
 				"context": {
 				   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
@@ -492,6 +568,7 @@ func TestCloudEventFunction(t *testing.T) {
 		},
 		{
 			name: "panic returns 500",
+			path: "/TestRegisterCloudEventFunctionContext_panic",
 			body: cloudeventsJSON,
 			fn: func(ctx context.Context, e cloudevents.Event) error {
 				panic("intentional panic for test")
@@ -503,6 +580,7 @@ func TestCloudEventFunction(t *testing.T) {
 		},
 		{
 			name: "error returns 500",
+			path: "/TestRegisterCloudEventFunctionContext_error",
 			body: cloudeventsJSON,
 			fn: func(ctx context.Context, e cloudevents.Event) error {
 				return fmt.Errorf("error for test")
@@ -518,11 +596,13 @@ func TestCloudEventFunction(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			h, err := wrapCloudEventFunction(ctx, "/", tc.fn)
-			defer func() { handler = nil }()
-			if err != nil {
-				t.Fatalf("registerCloudEventFunction(): %v", err)
+			if len(tc.target) > 0 {
+				os.Setenv("FUNCTION_TARGET", tc.target)
+				defer os.Unsetenv("FUNCTION_TARGET")
+			}
+			
+			if err := RegisterCloudEventFunctionContext(context.Background(), tc.path, tc.fn); err != nil {
+				t.Fatalf("RegisterCloudEventFunctionContext(): %v", err)
 			}
 
 			// Capture stderr for the duration of the test case. This includes
@@ -532,10 +612,14 @@ func TestCloudEventFunction(t *testing.T) {
 			os.Stderr = w
 			defer func() { os.Stderr = origStderrPipe }()
 
-			srv := httptest.NewServer(h)
+			server, err := initServer()
+			if err != nil {
+				t.Fatalf("initServer(): %v", err)
+			}
+			srv := httptest.NewServer(server)
 			defer srv.Close()
 
-			req, err := http.NewRequest("POST", srv.URL, bytes.NewBuffer(tc.body))
+			req, err := http.NewRequest("POST", srv.URL+tc.path, bytes.NewBuffer(tc.body))
 			if err != nil {
 				t.Fatalf("error creating HTTP request for test: %v", err)
 			}
@@ -586,49 +670,67 @@ func TestCloudEventFunction(t *testing.T) {
 
 func TestDeclarativeFunctionHTTP(t *testing.T) {
 	funcName := "httpfunc"
+	funcResp := "Hello World!"
 	os.Setenv("FUNCTION_TARGET", funcName)
+	defer os.Unsetenv("FUNCTION_TARGET")
 
+	// Verify RegisterHTTPFunctionContext and functions.HTTP don't conflict.
 	if err := RegisterHTTPFunctionContext(context.Background(), "/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "Hello World!")
 	}); err != nil {
-		t.Fatalf("registerHTTPFunction(): %v", err)
+		t.Fatalf("RegisterHTTPFunctionContext(): %v", err)
 	}
-	defer func() { handler = nil }()
-	// register functions
+	defer registry.Default().DeleteRegisteredFunction("function_at_path_\"/\"")
+	// Register functions.
 	functions.HTTP(funcName, func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "Hello World!")
+		fmt.Fprint(w, funcResp)
 	})
-
 	if _, ok := registry.Default().GetRegisteredFunction(funcName); !ok {
-		t.Fatalf("could not get registered function: %s", funcName)
+		t.Fatalf("could not get registered function: %q", funcName)
 	}
 
-	srv := httptest.NewServer(handler)
+	server, err := initServer()
+	if err != nil {
+		t.Fatalf("initServer(): %v", err)
+	}
+	srv := httptest.NewServer(server)
 	defer srv.Close()
 
-	if _, err := http.Get(srv.URL); err != nil {
-		t.Fatalf("could not make HTTP GET request to function: %s", err)
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("could not make HTTP GET request to function: %q", err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ioutil.ReadAll: %v", err)
+	}
+	if got := strings.TrimSpace(string(body)); got != funcResp {
+		t.Errorf("unexpected http response: got %q; want: %q", got, funcResp)
 	}
 }
 
 func TestDeclarativeFunctionCloudEvent(t *testing.T) {
 	funcName := "cloudeventfunc"
 	os.Setenv("FUNCTION_TARGET", funcName)
+	defer os.Unsetenv("FUNCTION_TARGET")
 
+	// Verify RegisterCloudEventFunctionContext and functions.CloudEvent don't conflict.
 	if err := RegisterCloudEventFunctionContext(context.Background(), "/", dummyCloudEvent); err != nil {
 		t.Fatalf("registerHTTPFunction(): %v", err)
 	}
-
+	defer registry.Default().DeleteRegisteredFunction("function_at_path_\"/\"")
 	// register functions
 	functions.CloudEvent(funcName, dummyCloudEvent)
-
-	//cleanup global var
-	defer func() { handler = nil }()
 	if _, ok := registry.Default().GetRegisteredFunction(funcName); !ok {
 		t.Fatalf("could not get registered function: %s", funcName)
 	}
 
-	srv := httptest.NewServer(handler)
+	server, err := initServer()
+	if err != nil {
+		t.Fatalf("initServer(): %v", err)
+	}
+	srv := httptest.NewServer(server)
 	defer srv.Close()
 
 	if _, err := http.Get(srv.URL); err != nil {
@@ -639,6 +741,7 @@ func TestDeclarativeFunctionCloudEvent(t *testing.T) {
 func TestFunctionsNotRegisteredError(t *testing.T) {
 	funcName := "HelloWorld"
 	os.Setenv("FUNCTION_TARGET", funcName)
+	defer os.Unsetenv("FUNCTION_TARGET")
 
 	wantErr := fmt.Sprintf("no matching function found with name: %q", funcName)
 
@@ -649,4 +752,56 @@ func TestFunctionsNotRegisteredError(t *testing.T) {
 
 func dummyCloudEvent(ctx context.Context, e cloudevents.Event) error {
 	return nil
+}
+
+func TestServeMultipleFunctions(t *testing.T) {
+	fns := []struct {
+		name     string
+		fn       func(w http.ResponseWriter, r *http.Request)
+		wantResp string
+	}{
+		{
+			name: "fn1",
+			fn: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, "Hello Foo!")
+			},
+			wantResp: "Hello Foo!",
+		},
+		{
+			name: "fn2",
+			fn: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, "Hello Bar!")
+			},
+			wantResp: "Hello Bar!",
+		},
+	}
+
+	// Register functions.
+	for _, f := range fns {
+		functions.HTTP(f.name, f.fn)
+		if _, ok := registry.Default().GetRegisteredFunction(f.name); !ok {
+			t.Fatalf("could not get registered function: %s", f.name)
+		}
+	}
+
+	server, err := initServer()
+	if err != nil {
+		t.Fatalf("initServer(): %v", err)
+	}
+	srv := httptest.NewServer(server)
+	defer srv.Close()
+
+	for _, f := range fns {
+		resp, err := http.Get(srv.URL + "/" + f.name)
+		if err != nil {
+			t.Fatalf("could not make HTTP GET request to function: %s", err)
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("ioutil.ReadAll: %v", err)
+		}
+		if got := strings.TrimSpace(string(body)); got != f.wantResp {
+			t.Errorf("unexpected http response: got %q; want: %q", got, f.wantResp)
+		}
+	}
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -12,13 +12,32 @@ import (
 // registered with the registry.
 type RegisteredFunction struct {
 	Name         string                                         // The name of the function
+	Path         string                                         // The serving path of the function
 	CloudEventFn func(context.Context, cloudevents.Event) error // Optional: The user's CloudEvent function
 	HTTPFn       func(http.ResponseWriter, *http.Request)       // Optional: The user's HTTP function
+	EventFn      interface{}                                    // Optional: The user's Event function
+	legacy       bool                                           // Optional: The function is registered non-declaratively
+}
+
+// Option is an option used when registering a function.
+type Option func(*RegisteredFunction)
+
+func WithPath(path string) Option {
+	return func(fn *RegisteredFunction) {
+		fn.Path = path
+	}
+}
+
+func WithLegacy() Option {
+	return func(fn *RegisteredFunction) {
+		fn.legacy = true
+	}
 }
 
 // Registry is a registry of functions.
 type Registry struct {
-	functions map[string]RegisteredFunction
+	functions    map[string]RegisteredFunction
+	lastLegacyFn RegisteredFunction // The last function that's not registered declaratively.
 }
 
 var defaultInstance = New()
@@ -35,27 +54,67 @@ func New() *Registry {
 }
 
 // RegisterHTTP a HTTP function with a given name
-func (r *Registry) RegisterHTTP(name string, fn func(http.ResponseWriter, *http.Request)) error {
+func (r *Registry) RegisterHTTP(name string, fn func(http.ResponseWriter, *http.Request), options ...Option) error {
 	if _, ok := r.functions[name]; ok {
-		return fmt.Errorf("function name already registered: %s", name)
+		return fmt.Errorf("function name already registered: %q", name)
 	}
-	r.functions[name] = RegisteredFunction{
+	function := RegisteredFunction{
 		Name:         name,
+		Path:         "/" + name,
 		CloudEventFn: nil,
 		HTTPFn:       fn,
+		EventFn:      nil,
+	}
+	for _, o := range options {
+		o(&function)
+	}
+	r.functions[name] = function
+	if function.legacy {
+		r.lastLegacyFn = function
 	}
 	return nil
 }
 
 // RegistryCloudEvent a CloudEvent function with a given name
-func (r *Registry) RegisterCloudEvent(name string, fn func(context.Context, cloudevents.Event) error) error {
+func (r *Registry) RegisterCloudEvent(name string, fn func(context.Context, cloudevents.Event) error, options ...Option) error {
 	if _, ok := r.functions[name]; ok {
-		return fmt.Errorf("function name already registered: %s", name)
+		return fmt.Errorf("function name already registered: %q", name)
 	}
-	r.functions[name] = RegisteredFunction{
+	function := RegisteredFunction{
 		Name:         name,
+		Path:         "/" + name,
 		CloudEventFn: fn,
 		HTTPFn:       nil,
+		EventFn:      nil,
+	}
+	for _, o := range options {
+		o(&function)
+	}
+	r.functions[name] = function
+	if function.legacy {
+		r.lastLegacyFn = function
+	}
+	return nil
+}
+
+// RegistryCloudEvent a Event function with a given name
+func (r *Registry) RegisterEvent(name string, fn interface{}, options ...Option) error {
+	if _, ok := r.functions[name]; ok {
+		return fmt.Errorf("function name already registered: %q", name)
+	}
+	function := RegisteredFunction{
+		Name:         name,
+		Path:         "/" + name,
+		CloudEventFn: nil,
+		HTTPFn:       nil,
+		EventFn:      fn,
+	}
+	for _, o := range options {
+		o(&function)
+	}
+	r.functions[name] = function
+	if function.legacy {
+		r.lastLegacyFn = function
 	}
 	return nil
 }
@@ -64,4 +123,23 @@ func (r *Registry) RegisterCloudEvent(name string, fn func(context.Context, clou
 func (r *Registry) GetRegisteredFunction(name string) (RegisteredFunction, bool) {
 	fn, ok := r.functions[name]
 	return fn, ok
+}
+
+// GetAllFunctions returns all the registered functions.
+func (r *Registry) GetAllFunctions() map[string]RegisteredFunction {
+	return r.functions
+}
+
+// GetLastLegacyFunction returns the last function that's not registered declaratively.
+func (r *Registry) GetLastLegacyFunction() (RegisteredFunction, bool) {
+	// No function is registered non-declaratively.
+	if len(r.lastLegacyFn.Name) == 0 {
+		return r.lastLegacyFn, false
+	}
+	return r.lastLegacyFn, true
+}
+
+// DeleteRegisteredFunction deletes a registered function.
+func (r *Registry) DeleteRegisteredFunction(name string) {
+	delete(r.functions, name)
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,32 +23,170 @@ import (
 )
 
 func TestRegisterHTTP(t *testing.T) {
-	registry := New()
-	registry.RegisterHTTP("httpfn", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "Hello World!")
-	})
-
-	fn, ok := registry.GetRegisteredFunction("httpfn")
-	if !ok {
-		t.Fatalf("Expected function to be registered")
+	testCases := []struct {
+		name       string
+		option     Option
+		wantName   string
+		wantPath   string
+		wantLegacy bool
+	}{
+		{
+			name:     "hello",
+			wantName: "hello",
+			wantPath: "/hello",
+		},
+		{
+			name:     "withPath",
+			option:   WithPath("/world"),
+			wantName: "withPath",
+			wantPath: "/world",
+		},
+		{
+			name:       "withLegacy",
+			option:     WithLegacy(),
+			wantName:   "withLegacy",
+			wantPath:   "/withLegacy",
+			wantLegacy: true,
+		},
 	}
-	if fn.Name != "httpfn" {
-		t.Errorf("Expected function name to be 'httpfn', got %s", fn.Name)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := New()
+
+			httpfn := func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, "Hello World!") }
+			if tc.option != nil {
+				registry.RegisterHTTP(tc.name, httpfn, tc.option)
+			} else {
+				registry.RegisterHTTP(tc.name, httpfn)
+			}
+
+			fn, ok := registry.GetRegisteredFunction(tc.name)
+			if !ok {
+				t.Fatalf("Expected function to be registered")
+			}
+			if fn.Name != tc.wantName {
+				t.Errorf("Expected function name to be %s, got %s", tc.wantName, fn.Name)
+			}
+			if fn.Path != tc.wantPath {
+				t.Errorf("Expected function path to be %s, got %s", tc.wantPath, fn.Path)
+			}
+			if fn.legacy != tc.wantLegacy {
+				t.Errorf("Expected function legacy to be %v, got %v", tc.wantLegacy, fn.legacy)
+			}
+		})
 	}
 }
 
-func TestRegisterCE(t *testing.T) {
-	registry := New()
-	registry.RegisterCloudEvent("cefn", func(context.Context, cloudevents.Event) error {
-		return nil
-	})
-
-	fn, ok := registry.GetRegisteredFunction("cefn")
-	if !ok {
-		t.Fatalf("Expected function to be registered")
+func TestRegisterCloudEvent(t *testing.T) {
+	testCases := []struct {
+		name       string
+		option     Option
+		wantName   string
+		wantPath   string
+		wantLegacy bool
+	}{
+		{
+			name:     "hello",
+			wantName: "hello",
+			wantPath: "/hello",
+		},
+		{
+			name:     "withPath",
+			option:   WithPath("/world"),
+			wantName: "withPath",
+			wantPath: "/world",
+		},
+		{
+			name:       "withLegacy",
+			option:     WithLegacy(),
+			wantName:   "withLegacy",
+			wantPath:   "/withLegacy",
+			wantLegacy: true,
+		},
 	}
-	if fn.Name != "cefn" {
-		t.Errorf("Expected function name to be 'cefn', got %s", fn.Name)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := New()
+
+			cefn := func(context.Context, cloudevents.Event) error { return nil }
+			if tc.option != nil {
+				registry.RegisterCloudEvent(tc.name, cefn, tc.option)
+			} else {
+				registry.RegisterCloudEvent(tc.name, cefn)
+			}
+
+			fn, ok := registry.GetRegisteredFunction(tc.name)
+			if !ok {
+				t.Fatalf("Expected function to be registered")
+			}
+			if fn.Name != tc.wantName {
+				t.Errorf("Expected function name to be %s, got %s", tc.wantName, fn.Name)
+			}
+			if fn.Path != tc.wantPath {
+				t.Errorf("Expected function path to be %s, got %s", tc.wantPath, fn.Path)
+			}
+			if fn.legacy != tc.wantLegacy {
+				t.Errorf("Expected function legacy to be %v, got %v", tc.wantLegacy, fn.legacy)
+			}
+		})
+	}
+}
+
+func TestRegisterEvent(t *testing.T) {
+	testCases := []struct {
+		name       string
+		option     Option
+		wantName   string
+		wantPath   string
+		wantLegacy bool
+	}{
+		{
+			name:     "hello",
+			wantName: "hello",
+			wantPath: "/hello",
+		},
+		{
+			name:     "withPath",
+			option:   WithPath("/world"),
+			wantName: "withPath",
+			wantPath: "/world",
+		},
+		{
+			name:       "withLegacy",
+			option:     WithLegacy(),
+			wantName:   "withLegacy",
+			wantPath:   "/withLegacy",
+			wantLegacy: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := New()
+
+			eventfn := func() {}
+			if tc.option != nil {
+				registry.RegisterEvent(tc.name, eventfn, tc.option)
+			} else {
+				registry.RegisterEvent(tc.name, eventfn)
+			}
+
+			fn, ok := registry.GetRegisteredFunction(tc.name)
+			if !ok {
+				t.Fatalf("Expected function to be registered")
+			}
+			if fn.Name != tc.wantName {
+				t.Errorf("Expected function name to be %s, got %s", tc.wantName, fn.Name)
+			}
+			if fn.Path != tc.wantPath {
+				t.Errorf("Expected function path to be %s, got %s", tc.wantPath, fn.Path)
+			}
+			if fn.legacy != tc.wantLegacy {
+				t.Errorf("Expected function legacy to be %v, got %v", tc.wantLegacy, fn.legacy)
+			}
+		})
 	}
 }
 
@@ -59,9 +197,7 @@ func TestRegisterMultipleFunctions(t *testing.T) {
 	}); err != nil {
 		t.Error("Expected \"multifn1\" function to be registered")
 	}
-	if err := registry.RegisterHTTP("multifn2", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "Hello World 2!")
-	}); err != nil {
+	if err := registry.RegisterEvent("multifn2", func() {}); err != nil {
 		t.Error("Expected \"multifn2\" function to be registered")
 	}
 	if err := registry.RegisterCloudEvent("multifn3", func(context.Context, cloudevents.Event) error {


### PR DESCRIPTION
There are two ways to test multiple functions within one server. 

1. Declaratively register multiple functions (e.g. calling `functions.HTTP()`) and run `go run cmd/main.go` without setting the env var `FUNCTION_TARGET`. In this case, all registered functions will be served  at "/{func_name}".
2. Manually register the handers (e.g. calling `funcframework.RegisterHTTPFunctionContext()`)  and run `go run cmd/main.go` without setting the env var `FUNCTION_TARGET`. In this case,  the registered handlers will be served at the user defined path.

Closes #109 