### PR TITLE
feat: Add support for strongly typed function signature

### DIFF
--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -228,7 +228,7 @@ func wrapTypedFunction(fn interface{}) (http.Handler, error) {
 		argVal := inputType
 
 		if err := json.Unmarshal(body, argVal.Interface()); err != nil {
-			writeHTTPErrorResponse(w, http.StatusBadRequest, crashStatus, fmt.Sprintf("Error while converting input type data: %s. %s", string(body), err.Error()))
+			writeHTTPErrorResponse(w, http.StatusBadRequest, crashStatus, fmt.Sprintf("Error while converting input data. %s", err.Error()))
 			return
 		}
 

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -228,7 +228,7 @@ func wrapTypedFunction(fn interface{}) (http.Handler, error) {
 		argVal := inputType
 
 		if err := json.Unmarshal(body, argVal.Interface()); err != nil {
-			writeHTTPErrorResponse(w, http.StatusBadRequest, crashStatus, fmt.Sprintf("Error: %s, while converting input type data: %s", err.Error(), string(body)))
+			writeHTTPErrorResponse(w, http.StatusBadRequest, crashStatus, fmt.Sprintf("Error while converting input type data: %s. %s", string(body), err.Error()))
 			return
 		}
 

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -235,13 +235,10 @@ func wrapTypedFunction(fn interface{}) (http.Handler, error) {
 			argVal.Elem(),
 		})
 
-		fmt.Printf("User error %s", funcReturn)
-
 		if len(funcReturn) >= 1 {
 			var errorVar error
 			errorType := reflect.TypeOf(&errorVar).Elem()
 			firstVal := funcReturn[0].Interface()
-			fmt.Println(reflect.TypeOf(firstVal))
 			if !reflect.TypeOf(firstVal).AssignableTo(errorType) {
 				returnVal, _ := json.Marshal(firstVal)
 				fmt.Fprintf(w, string(returnVal))

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -243,16 +243,16 @@ func wrapTypedFunction(fn interface{}) (http.Handler, error) {
 }
 
 func handleTypedReturn(funcReturn []reflect.Value, w http.ResponseWriter) {
-	if len(funcReturn) > 0 {
-		errorVal := funcReturn[len(funcReturn)-1].Interface() // last return must be of type error
-		firstVal := funcReturn[0].Interface()
-		if errorVal != nil && reflect.TypeOf(errorVal).AssignableTo(errorType) {
-			writeHTTPErrorResponse(w, http.StatusInternalServerError, errorStatus, fmtFunctionError(errorVal))
-		} else if !reflect.TypeOf(firstVal).AssignableTo(errorType) {
-			returnVal, _ := json.Marshal(firstVal)
-			fmt.Fprintf(w, string(returnVal))
-		}
-
+	if len(funcReturn) == 0 {
+		return
+	}
+	errorVal := funcReturn[len(funcReturn)-1].Interface() // last return must be of type error
+	firstVal := funcReturn[0].Interface()
+	if errorVal != nil && reflect.TypeOf(errorVal).AssignableTo(errorType) {
+		writeHTTPErrorResponse(w, http.StatusInternalServerError, errorStatus, fmtFunctionError(errorVal))
+	} else if !reflect.TypeOf(firstVal).AssignableTo(errorType) {
+		returnVal, _ := json.Marshal(firstVal)
+		fmt.Fprintf(w, string(returnVal))
 	}
 }
 

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -219,7 +219,7 @@ func TestRegisterTypedFunction(t *testing.T) {
 			},
 			status:     http.StatusBadRequest,
 			header:     "crash",
-			wantStderr: "while converting input type data",
+			wantStderr: "while converting input data",
 		},
 		{
 			name: "TestTypedFunction_func_error",

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -156,6 +156,18 @@ func TestRegisterTypedFunction(t *testing.T) {
 			header:     "crash",
 			wantStderr: "while converting input type data",
 		},
+		{
+			name: "function error",
+			path: "/TestRegisterTypedFunction_func_error",
+			body: []byte(`{"id": 0,"name": "john"}`),
+			fn: func(s customStruct) customStruct {
+				s.ID = 10 / s.ID
+				return s
+			},
+			status:     http.StatusInternalServerError,
+			header:     "crash",
+			wantStderr: "A panic occurred during user function execution",
+		},
 	}
 
 	for _, tc := range tests {

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -121,6 +121,120 @@ type eventData struct {
 	Data string `json:"data"`
 }
 
+func TestRegisterTypedFunction(t *testing.T) {
+	var tests = []struct {
+		name       string
+		path       string
+		body       []byte
+		fn         func(customStruct) customStruct
+		target     string
+		status     int
+		header     string
+		ceHeaders  map[string]string
+		wantResp   string
+		wantStderr string
+	}{
+		{
+			name: "typed function",
+			path: "/TestRegisterTypedFunction_typed",
+			body: []byte(`{"id": 12345,"name": "custom"}`),
+			fn: func(s customStruct) customStruct {
+				return s
+			},
+			status:   http.StatusOK,
+			header:   "",
+			wantResp: "{\"id\":12345,\"name\":\"custom\"}",
+		},
+		{
+			name: "input data error",
+			path: "/TestRegisterTypedFunction_data_error",
+			body: []byte(`{"id": 12345,"name": 5}`),
+			fn: func(s customStruct) customStruct {
+				return s
+			},
+			status:     http.StatusBadRequest,
+			header:     "crash",
+			wantStderr: "while converting input type data",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer cleanup()
+			if len(tc.target) > 0 {
+				os.Setenv("FUNCTION_TARGET", tc.target)
+			}
+
+			if err := RegisterTypedFunctionContext(context.Background(), tc.path, tc.fn); err != nil {
+				t.Fatalf("RegisterTypedFunctionContext(): %v", err)
+			}
+
+			origStderrPipe := os.Stderr
+			r, w, _ := os.Pipe()
+			os.Stderr = w
+			defer func() { os.Stderr = origStderrPipe }()
+
+			server, err := initServer()
+			if err != nil {
+				t.Fatalf("initServer(): %v", err)
+			}
+			srv := httptest.NewServer(server)
+			defer srv.Close()
+
+			req, err := http.NewRequest("POST", srv.URL+tc.path, bytes.NewBuffer(tc.body))
+			if err != nil {
+				t.Fatalf("error creating HTTP request for test: %v", err)
+			}
+			for k, v := range tc.ceHeaders {
+				req.Header.Add(k, v)
+			}
+
+			client := &http.Client{}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("client.Do(%s): %v", tc.name, err)
+			}
+
+			if err := w.Close(); err != nil {
+				t.Fatalf("failed to close stderr write pipe: %v", err)
+			}
+
+			stderr, err := ioutil.ReadAll(r)
+			if err != nil {
+				t.Errorf("failed to read stderr read pipe: %v", err)
+			}
+
+			if err := r.Close(); err != nil {
+				t.Fatalf("failed to close stderr read pipe: %v", err)
+			}
+
+			if !strings.Contains(string(stderr), tc.wantStderr) {
+				t.Errorf("stderr mismatch, got: %q, must contain: %q", string(stderr), tc.wantStderr)
+			}
+
+			if tc.wantStderr != "" && !strings.Contains(string(stderr), tc.wantStderr) {
+				t.Errorf("stderr mismatch, got: %q, must contain: %q", string(stderr), tc.wantStderr)
+			}
+
+			gotBody, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("unable to read got request body: %v", err)
+			}
+
+			if tc.wantResp != "" && string(gotBody) != tc.wantResp {
+				t.Errorf("TestTypedFunction(%s): response body = %q, want %q on error status code %d.", tc.name, gotBody, tc.wantResp, tc.status)
+			}
+
+			if resp.StatusCode != tc.status {
+				t.Errorf("TestTypedFunction(%s): response status = %v, want %v, %q.", tc.name, resp.StatusCode, tc.status, string(gotBody))
+			}
+			if resp.Header.Get(functionStatusHeader) != tc.header {
+				t.Errorf("TestTypedFunction(%s): response header = %q, want %q", tc.name, resp.Header.Get(functionStatusHeader), tc.header)
+			}
+		})
+	}
+}
+
 func TestRegisterEventFunctionContext(t *testing.T) {
 	var tests = []struct {
 		name       string

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -142,18 +142,28 @@ func TestRegisterTypedFunction(t *testing.T) {
 		{
 			name: "TestTypedFunction_typed",
 			body: []byte(`{"id": 12345,"name": "custom"}`),
-			fn: func(s customStruct) customStruct {
-				return s
+			fn: func(s customStruct) (customStruct, error) {
+				return s, nil
 			},
 			status:   http.StatusOK,
 			header:   "",
 			wantResp: `{"id":12345,"name":"custom"}`,
 		},
 		{
+			name: "TestTypedFunction_no_return",
+			body: []byte(`{"id": 12345,"name": "custom"}`),
+			fn: func(s customStruct) {
+
+			},
+			status:   http.StatusOK,
+			header:   "",
+			wantResp: "",
+		},
+		{
 			name: "TestTypedFunction_untagged_struct",
 			body: []byte(`{"Age": 30,"Name": "john"}`),
-			fn: func(s testStruct) testStruct {
-				return s
+			fn: func(s testStruct) (testStruct, error) {
+				return s, nil
 			},
 			status:   http.StatusOK,
 			header:   "",
@@ -170,14 +180,25 @@ func TestRegisterTypedFunction(t *testing.T) {
 			wantResp: `{"id":12345,"name":"custom"}`,
 		},
 		{
-			name: "TestTypedFunction_return_string",
+			name: "TestTypedFunction_return_int",
 			body: []byte(`{"id": 12345,"name": "custom"}`),
-			fn: func(s customStruct) int {
-				return s.ID
+			fn: func(s customStruct) (int, error) {
+				return s.ID, nil
 			},
 			status:   http.StatusOK,
 			header:   "",
 			wantResp: "12345",
+		},
+		{
+			name: "TestTypedFunction_different_types",
+			body: []byte(`{"id": 12345,"name": "custom"}`),
+			fn: func(s customStruct) (testStruct, error) {
+				var t = testStruct{99, "John"}
+				return t, nil
+			},
+			status:   http.StatusOK,
+			header:   "",
+			wantResp: `{"Age":99,"Name":"John"}`,
 		},
 		{
 			name: "TestTypedFunction_return_error",
@@ -193,8 +214,8 @@ func TestRegisterTypedFunction(t *testing.T) {
 		{
 			name: "TestTypedFunction_data_error",
 			body: []byte(`{"id": 12345,"name": 5}`),
-			fn: func(s customStruct) customStruct {
-				return s
+			fn: func(s customStruct) (customStruct, error) {
+				return s, nil
 			},
 			status:     http.StatusBadRequest,
 			header:     "crash",
@@ -203,9 +224,9 @@ func TestRegisterTypedFunction(t *testing.T) {
 		{
 			name: "TestTypedFunction_func_error",
 			body: []byte(`{"id": 0,"name": "john"}`),
-			fn: func(s customStruct) customStruct {
+			fn: func(s customStruct) (customStruct, error) {
 				s.ID = 10 / s.ID
-				return s
+				return s, nil
 			},
 			status:     http.StatusInternalServerError,
 			header:     "crash",

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -117,6 +117,11 @@ type customStruct struct {
 	Name string `json:"name"`
 }
 
+type testStruct struct {
+	Age  int
+	Name string
+}
+
 type eventData struct {
 	Data string `json:"data"`
 }
@@ -142,7 +147,17 @@ func TestRegisterTypedFunction(t *testing.T) {
 			},
 			status:   http.StatusOK,
 			header:   "",
-			wantResp: "{\"id\":12345,\"name\":\"custom\"}",
+			wantResp: `{"id":12345,"name":"custom"}`,
+		},
+		{
+			name: "TestTypedFunction_untagged_struct",
+			body: []byte(`{"Age": 30,"Name": "john"}`),
+			fn: func(s testStruct) testStruct {
+				return s
+			},
+			status:   http.StatusOK,
+			header:   "",
+			wantResp: `{"Age":30,"Name":"john"}`,
 		},
 		{
 			name: "TestTypedFunction_two_returns",
@@ -152,7 +167,7 @@ func TestRegisterTypedFunction(t *testing.T) {
 			},
 			status:   http.StatusOK,
 			header:   "",
-			wantResp: "{\"id\":12345,\"name\":\"custom\"}",
+			wantResp: `{"id":12345,"name":"custom"}`,
 		},
 		{
 			name: "TestTypedFunction_return_string",

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -26,3 +26,9 @@ func CloudEvent(name string, fn func(context.Context, cloudevents.Event) error) 
 		log.Fatalf("failure to register function: %s", err)
 	}
 }
+
+func Typed(name string, fn interface{}) {
+	if err := registry.Default().RegisterTyped(fn, registry.WithName(name)); err != nil {
+		log.Fatalf("failure to register function: %s", err)
+	}
+}

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -28,7 +28,7 @@ func CloudEvent(name string, fn func(context.Context, cloudevents.Event) error) 
 }
 
 // Typed registers a Typed function that becomes the function handler
-// served at "/" whenh environment variable `FUNCTION_TARGET=name`
+// served at "/" when environment variable `FUNCTION_TARGET=name`
 // This function takes a strong type T as an input and can return a strong type T,
 // built in types, nil and/or error as an output
 func Typed(name string, fn interface{}) {

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -27,6 +27,10 @@ func CloudEvent(name string, fn func(context.Context, cloudevents.Event) error) 
 	}
 }
 
+// Typed registers a Typed function that becomes the function handler
+// served at "/" whenh environment variable `FUNCTION_TARGET=name`
+// This function takes a strong type T as an input and can return a strong type T,
+// built in types, nil and/or error as an output
 func Typed(name string, fn interface{}) {
 	if err := registry.Default().RegisterTyped(fn, registry.WithName(name)); err != nil {
 		log.Fatalf("failure to register function: %s", err)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -68,7 +68,7 @@ func (r *Registry) RegisterCloudEvent(fn func(context.Context, cloudevents.Event
 	return r.register(&RegisteredFunction{CloudEventFn: fn}, options...)
 }
 
-// RegisterCloudEvent registers a Event function.
+// RegisterEvent registers an Event function.
 func (r *Registry) RegisterEvent(fn interface{}, options ...Option) error {
 	return r.register(&RegisteredFunction{EventFn: fn}, options...)
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -16,6 +16,7 @@ type RegisteredFunction struct {
 	CloudEventFn func(context.Context, cloudevents.Event) error // Optional: The user's CloudEvent function
 	HTTPFn       func(http.ResponseWriter, *http.Request)       // Optional: The user's HTTP function
 	EventFn      interface{}                                    // Optional: The user's Event function
+	TypedFn      interface{}                                    // Optional: The user's typed function
 }
 
 // Option is an option used when registering a function.
@@ -62,14 +63,19 @@ func (r *Registry) RegisterHTTP(fn func(http.ResponseWriter, *http.Request), opt
 	return r.register(&RegisteredFunction{HTTPFn: fn}, options...)
 }
 
-// RegistryCloudEvent registers a CloudEvent function.
+// RegisterCloudEvent registers a CloudEvent function.
 func (r *Registry) RegisterCloudEvent(fn func(context.Context, cloudevents.Event) error, options ...Option) error {
 	return r.register(&RegisteredFunction{CloudEventFn: fn}, options...)
 }
 
-// RegistryCloudEvent registers a Event function.
+// RegisterCloudEvent registers a Event function.
 func (r *Registry) RegisterEvent(fn interface{}, options ...Option) error {
 	return r.register(&RegisteredFunction{EventFn: fn}, options...)
+}
+
+// RegisterTyped registers a strongly typed function.
+func (r *Registry) RegisterTyped(fn interface{}, options ...Option) error {
+	return r.register(&RegisteredFunction{TypedFn: fn}, options...)
 }
 
 func (r *Registry) register(function *RegisteredFunction, options ...Option) error {


### PR DESCRIPTION
Add a new signature in functions framework that will support strongly typed objects. This signature will take a strong type T as an input and can return a strong type T, built in types, None and/or error as an output.

Sample declarations:
`func helloWorld(s T) (T, error) `

`func helloWorld(s T1) (T2, error) `

`func helloWorld(s T1)`

`func helloWorld(s T1) error`