### PR TITLE
[Automation] Update go matrix

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.13', '1.16', '1.18', '1.19', '1.20']
+        go: ['1.11', '1.13', '1.16', '1.18', '1.19', '1.20']
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: Harden Runner


### PR DESCRIPTION
- go matrix updates

Update the go matrix in the CI workflows to include the new supported runtimes.

Auto-generated by https://github.com/chizhg/serverless-runtimes-automation/actions/runs/4720039484