### PR TITLE
fix: attempt to log panic error in one logging entry

### DIFF
--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -49,7 +49,7 @@ var errorType = reflect.TypeOf((*error)(nil)).Elem()
 func recoverPanic(w http.ResponseWriter, panicSrc string) {
 	if r := recover(); r != nil {
 		genericMsg := fmt.Sprintf(panicMessageTmpl, panicSrc)
-		fmt.Fprintf(os.Stderr, fmt.Sprintf("%s\npanic message: %v\nstack trace: \n%s", genericMsg, r, debug.Stack()))
+		fmt.Fprintf(os.Stderr, "%s\npanic message: %v - stack trace:\n%s", genericMsg, r, debug.Stack())
 		if w != nil {
 			writeHTTPErrorResponse(w, http.StatusInternalServerError, crashStatus, genericMsg)
 		}

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -49,7 +49,7 @@ var errorType = reflect.TypeOf((*error)(nil)).Elem()
 func recoverPanic(w http.ResponseWriter, panicSrc string) {
 	if r := recover(); r != nil {
 		genericMsg := fmt.Sprintf(panicMessageTmpl, panicSrc)
-		fmt.Fprintf(os.Stderr, "%s\npanic message: %v\nstack trace: \n%s", genericMsg, r, debug.Stack())
+		fmt.Fprintf(os.Stderr, fmt.Sprintf("%s\npanic message: %v\nstack trace: \n%s", genericMsg, r, debug.Stack()))
 		if w != nil {
 			writeHTTPErrorResponse(w, http.StatusInternalServerError, crashStatus, genericMsg)
 		}


### PR DESCRIPTION
Seems like somehow, with a single added new line, we log to cloud logging in multiple entries instead of one. This attempts to fix that.