### PR TITLE
fix: correct formatting of status print

### DIFF
--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -149,7 +149,7 @@ func initServer() (*http.ServeMux, error) {
 func wrapFunction(fn *registry.RegisteredFunction) (http.Handler, error) {
 	// Check if we have a function resource set, and if so, log progress.
 	if os.Getenv("FUNCTION_TARGET") == "" {
-		fmt.Printf("Serving function: %q", fn.Name)
+		fmt.Printf("Serving function: %q\n", fn.Name)
 	}
 
 	if fn.HTTPFn != nil {


### PR DESCRIPTION
Fixes framework's status print "Serving function: ..." on startup when no target is specified in local dev (allows serving multiple functions from a single instance of function framework). Today the output looks like:
```
Serving function: "declarativeHTTP"Serving function: "concurrentHTTP"Serving function: "declarativeCloudEvent"
```
With the fix:
```
Serving function: "declarativeHTTP"
Serving function: "concurrentHTTP"
Serving function: "declarativeCloudEvent"
```