### PR TITLE
ci: [Automation] Update go matrix

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -27,6 +27,10 @@ jobs:
           proxy.golang.org:443
           cloud.google.com:443
           golang.org:443
+          go.uber.org:443
+          go.googlesource.com:443
+          go.uber.org:443
+          gopkg.in:443
 
     - name: Checkout code
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,6 +25,7 @@ jobs:
           github.com:443
           objects.githubusercontent.com:443
           proxy.golang.org:443
+          cloud.google.com:443
 
     - name: Checkout code
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.13', '1.16', '1.18', '1.19', '1.20']
+        go: ['1.11', '1.13', '1.16', '1.18', '1.19', '1.20', '1.21']
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: Harden Runner

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -31,6 +31,7 @@ jobs:
           go.googlesource.com:443
           go.uber.org:443
           gopkg.in:443
+          google.golang.org:443
 
     - name: Checkout code
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.11', '1.13', '1.16', '1.18', '1.19', '1.20', '1.21']
+        go: ['1.13', '1.16', '1.18', '1.19', '1.20', '1.21']
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: Harden Runner
@@ -25,14 +25,6 @@ jobs:
           github.com:443
           objects.githubusercontent.com:443
           proxy.golang.org:443
-          cloud.google.com:443
-          golang.org:443
-          go.uber.org:443
-          go.googlesource.com:443
-          go.uber.org:443
-          gopkg.in:443
-          google.golang.org:443
-          go.opencensus.io:443
 
     - name: Checkout code
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -32,6 +32,7 @@ jobs:
           go.uber.org:443
           gopkg.in:443
           google.golang.org:443
+          go.opencensus.io:443
 
     - name: Checkout code
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,6 +26,7 @@ jobs:
           objects.githubusercontent.com:443
           proxy.golang.org:443
           cloud.google.com:443
+          golang.org:443
 
     - name: Checkout code
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2


### PR DESCRIPTION
- go matrix updates

Update the go matrix in the CI workflows to include the new supported runtimes.

Auto-generated by https://github.com/chizhg/serverless-runtimes-automation/actions/runs/5901430748