### PR TITLE
ci: update harden-runner

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
       with:
         disable-sudo: true
         egress-policy: block

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -19,7 +19,7 @@ jobs:
       cache-key: ${{ steps.resolve-latest-client.outputs.version }}
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
       with:
         egress-policy: block
         allowed-endpoints: >
@@ -53,7 +53,7 @@ jobs:
         go-version: [1.13, 1.16, 1.18]
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@6b3083af2869dc3314a0257a42f4af696cc79ba3 # v2.3.1
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
       with:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest] # windows-latest doesn't support find -wholename
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
       with:
         disable-sudo: true
         egress-policy: block

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0
+        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
       with:
         disable-sudo: true
         egress-policy: block


### PR DESCRIPTION
This PR updates `step-security/harden-runner` from 2.5.0 to 2.5.1 in the GitHub Actions workflows.

GitHub Actions recently started making outbound calls to a few endpoints not in the default allowed list.   This causes the build to get stuck when using a `block` policy with `harden-runner`. This update to harden-runner (version v2.5.1), adds these new endpoints to the default allowed list. 

Release notes for the latest version are here:
https://github.com/step-security/harden-runner/releases/tag/v2.5.1

@kenneth-rosario 