### PR TITLE
chore: fix github action

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -32,6 +32,7 @@ jobs:
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version: ${{ matrix.go }}
+        architecture: 'x64'
     - name: Build and test
       run: "go test ./..."
     - name: Vet


### PR DESCRIPTION
macos-latest is now macos 14 which defaults to ARM and only supports Go >= 1.16. Updating config to use x64 instead