### PR TITLE
chore: Update unit.yml

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -32,6 +32,7 @@ jobs:
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version: ${{ matrix.go }}
+        check-latest: true
     - name: Build and test
       run: "go test ./..."
     - name: Vet


### PR DESCRIPTION
According to https://github.com/actions/setup-go/issues/454 this should resolve the issues installing go in the macos workflows