### PR TITLE
fix: cancel request context when timeout exceeded

### DIFF
--- a/funcframework/events.go
+++ b/funcframework/events.go
@@ -192,7 +192,7 @@ func convertBackgroundToCloudEvent(ceHandler http.Handler) http.Handler {
 				return
 			}
 		}
-		r, cancel := setTimeoutContextIfRequested(r)
+		r, cancel := setContextTimeoutIfRequested(r)
 		if cancel != nil {
 			defer cancel()
 		}

--- a/funcframework/events.go
+++ b/funcframework/events.go
@@ -192,6 +192,10 @@ func convertBackgroundToCloudEvent(ceHandler http.Handler) http.Handler {
 				return
 			}
 		}
+		r, cancel := setTimeoutContextIfRequested(r)
+		if cancel != nil {
+			defer cancel()
+		}
 		ceHandler.ServeHTTP(w, r)
 	})
 }

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -198,7 +198,7 @@ func wrapHTTPFunction(fn func(http.ResponseWriter, *http.Request)) (http.Handler
 			defer fmt.Println()
 			defer fmt.Fprintln(os.Stderr)
 		}
-		r, cancel := setTimeoutContextIfRequested(r)
+		r, cancel := setContextTimeoutIfRequested(r)
 		if cancel != nil {
 			defer cancel()
 		}
@@ -218,7 +218,7 @@ func wrapEventFunction(fn interface{}) (http.Handler, error) {
 			defer fmt.Println()
 			defer fmt.Fprintln(os.Stderr)
 		}
-		r, cancel := setTimeoutContextIfRequested(r)
+		r, cancel := setContextTimeoutIfRequested(r)
 		if cancel != nil {
 			defer cancel()
 		}
@@ -399,14 +399,14 @@ func writeHTTPErrorResponse(w http.ResponseWriter, statusCode int, status, msg s
 }
 
 // addTImeoutToRequestContext replaces the request's context with a cancellation if requested
-func setTimeoutContextIfRequested(r *http.Request) (*http.Request, func()) {
+func setContextTimeoutIfRequested(r *http.Request) (*http.Request, func()) {
 	timeoutStr := os.Getenv("CLOUD_RUN_TIMEOUT_SECONDS")
 	if timeoutStr == "" {
 		return r, nil
 	}
 	timeoutSecs, err := strconv.Atoi(timeoutStr)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not parse CLOUD_RUN_TIMEOUT_SECONDS as an integer value in seconds: %v", err)
+		fmt.Fprintf(os.Stderr, "Could not parse CLOUD_RUN_TIMEOUT_SECONDS as an integer value in seconds: %v\n", err)
 		return r, nil
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(timeoutSecs)*time.Second)

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -398,7 +398,7 @@ func writeHTTPErrorResponse(w http.ResponseWriter, statusCode int, status, msg s
 	fmt.Fprint(w, msg)
 }
 
-// addTImeoutToRequestContext replaces the request's context with a cancellation if requested
+// setContextTimeoutIfRequested replaces the request's context with a cancellation if requested
 func setContextTimeoutIfRequested(r *http.Request) (*http.Request, func()) {
 	timeoutStr := os.Getenv("CLOUD_RUN_TIMEOUT_SECONDS")
 	if timeoutStr == "" {

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -25,10 +25,12 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/GoogleCloudPlatform/functions-framework-go/internal/registry"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -992,6 +994,120 @@ func TestServeMultipleFunctions(t *testing.T) {
 		if got := strings.TrimSpace(string(body)); got != f.wantResp {
 			t.Errorf("unexpected http response: got %q; want: %q", got, f.wantResp)
 		}
+	}
+}
+
+func TestHTTPRequestTimeout(t *testing.T) {
+	timeoutEnvVar := "CLOUD_RUN_TIMEOUT_SECONDS"
+	prev := os.Getenv(timeoutEnvVar)
+	defer os.Setenv(timeoutEnvVar, prev)
+	defer cleanup()
+
+	cloudeventsJSON := []byte(`{
+		"specversion" : "1.0",
+		"type" : "com.github.pull.create",
+		"source" : "https://github.com/cloudevents/spec/pull",
+		"subject" : "123",
+		"id" : "A234-1234-1234",
+		"time" : "2018-04-05T17:31:00Z",
+		"comexampleextension1" : "value",
+		"datacontenttype" : "application/xml",
+		"data" : "<much wow=\"xml\"/>"
+	}`)
+
+	tcs := []struct {
+		name         string
+		wantDeadline bool
+		wantExpired  bool
+		timeout      string
+	}{
+		{
+			name:         "deadline not requested",
+			wantDeadline: false,
+			wantExpired:  false,
+			timeout:      "",
+		},
+		{
+			name:         "NaN deadline",
+			wantDeadline: false,
+			wantExpired:  false,
+			timeout:      "aaa",
+		},
+		{
+			name:         "zero deadline",
+			wantDeadline: true,
+			wantExpired:  true,
+			timeout:      "0",
+		},
+		{
+			name:         "very long deadline",
+			wantDeadline: true,
+			wantExpired:  false,
+			timeout:      "3600",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			defer cleanup()
+			os.Setenv(timeoutEnvVar, tc.timeout)
+
+			var httpReqCtx context.Context
+			functions.HTTP("http", func(w http.ResponseWriter, r *http.Request) {
+				httpReqCtx = r.Context()
+			})
+			var ceReqCtx context.Context
+			functions.CloudEvent("cloudevent", func(ctx context.Context, event event.Event) error {
+				ceReqCtx = ctx
+				return nil
+			})
+			server, err := initServer()
+			if err != nil {
+				t.Fatalf("initServer(): %v", err)
+			}
+			srv := httptest.NewServer(server)
+			defer srv.Close()
+
+			t.Run("http", func(t *testing.T) {
+				_, err = http.Get(srv.URL + "/http")
+				if err != nil {
+					t.Fatalf("expected success")
+				}
+				if httpReqCtx == nil {
+					t.Fatalf("expected non-nil request context")
+				}
+				deadline, ok := httpReqCtx.Deadline()
+				if ok != tc.wantDeadline {
+					t.Fatalf("expected deadline %v but got %v", tc.wantDeadline, ok)
+				}
+				if expired := deadline.Before(time.Now()); ok && expired != tc.wantExpired {
+					t.Fatalf("expected expired %v but got %v", tc.wantExpired, expired)
+				}
+			})
+
+			t.Run("cloudevent", func(t *testing.T) {
+				req, err := http.NewRequest("POST", srv.URL+"/cloudevent", bytes.NewBuffer(cloudeventsJSON))
+				if err != nil {
+					t.Fatalf("failed to create request")
+				}
+				req.Header.Add("Content-Type", "application/cloudevents+json")
+				_, err = (&http.Client{}).Do(req)
+				if err != nil {
+					t.Fatalf("request failed")
+				}
+
+				if ceReqCtx == nil {
+					t.Fatalf("expected non-nil request context")
+				}
+				deadline, ok := ceReqCtx.Deadline()
+				if ok != tc.wantDeadline {
+					t.Errorf("expected deadline %v but got %v", tc.wantDeadline, ok)
+				}
+				if expired := deadline.Before(time.Now()); ok && expired != tc.wantExpired {
+					t.Errorf("expected expired %v but got %v", tc.wantExpired, expired)
+				}
+			})
+		})
 	}
 }
 


### PR DESCRIPTION
This PR sets the request timeout (signaled by `CLOUD_RUN_TIMEOUT_SECONDS`) on the request context so that ff users can write functions that are deadline aware.

Functions overrunning `CLOUD_RUN_TIMEOUT_SECONDS` may continue to execute and spend CPU cycles but represent wasted work as the cloud functions runtime typically cuts off the response at this point, no data can be sent.