### PR TITLE
chore: Mention setting function target env variable when starting dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ handling logic.
 	)
 
 	func main() {
+        // Normally, you should start the local development server from the command
+		// line, but certain IDE's like Intellij and VSCode support directly running
+		// go applications inside the IDE directly. In these cases, the function won't
+		// be recognized. In these cases, set the "FUNCTION_TARGET" env variable directly
+        // to ensure the function is registered for the local server.
+        // err := os.Setenv("FUNCTION_TARGET", "HelloWorld")
+	    // if err != nil {
+		//     log.Fatalf("failed to set FUNCTION_TARGET: %v\n for local dev server", err)
+	    // }
+ 
 		// Use PORT environment variable, or default to 8080.
 		port := "8080"
 		if envPort := os.Getenv("PORT"); envPort != "" {


### PR DESCRIPTION
When starting the functions framework from the Intellij ide, the application throws 404 on each request:

function.go
```
package function

import (
	"fmt"
	"net/http"

	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
)

func init() {
	functions.HTTP("HelloWorld", helloWorld)
}

// helloWorld writes "Hello, World!" to the HTTP response.
func helloWorld(w http.ResponseWriter, r *http.Request) {
	fmt.Fprintln(w, "Hello, World!")
}
```

cmd/main.go
```
package main

import (
	"log"
	// Blank-import the function package so the init() runs
	"github.com/GoogleCloudPlatform/functions-framework-go/funcframework"
	_ "example.com/hello"
)

func main() {
	if err := funcframework.StartHostPort("127.0.0.1", "8082"); err != nil {
		log.Fatalf("funcframework.StartHostPort: %v\n", err)
	}
}
```

When starting a go app from an IDE, either set the "FUNCTION_TARGET" env variable or set manually in code:

```
package main

import (
	"log"
	// Blank-import the function package so the init() runs
	"github.com/GoogleCloudPlatform/functions-framework-go/funcframework"
	_ "example.com/hello"
)

func main() {
        err := os.Setenv("FUNCTION_TARGET", "HelloWorld")
	if err != nil {
		log.Fatalf("failed to set FUNCTION_TARGET: %v", err)
	}

	if err := funcframework.StartHostPort("127.0.0.1", "8082"); err != nil {
		log.Fatalf("funcframework.StartHostPort: %v\n", err)
	}
}
```

This PR adds commented code to the quickstart example mentioning that local servers started from IDE's require the function target env variable set to the function name.